### PR TITLE
Add reboot of nodes after k3s install

### DIFF
--- a/ansible/roles/k3s/tasks/control.yml
+++ b/ansible/roles/k3s/tasks/control.yml
@@ -20,4 +20,11 @@
       /tmp/k3s.sh
     creates: /var/lib/rancher/k3s/server/node-token
   when: is_control_plane
+  register: k3s_installed
   become: true
+
+- name: Set the k3s_install_occurred fact
+  ansible.builtin.set_fact: # noqa no-handler
+    k3s_install_occurred: true
+  when: k3s_installed.changed
+  changed_when: false

--- a/ansible/roles/k3s/tasks/main.yml
+++ b/ansible/roles/k3s/tasks/main.yml
@@ -48,3 +48,13 @@
   run_once: true
   register: control_plane_pods_ready
   changed_when: false
+
+# I don't know why this is required but we repeatedly have issues with ingress
+# install locking up on the ingress-nginx-nginx-admission-patch job. I have
+# added logic to the ingress task to reboot all nodes if the install fails but
+# this is clunky as that runs in a role for localhost. So I'm adding this here
+# to reboot all nodes in parallel once kube-system pods are ready.
+- name: Reboot nodes after installing k3s
+  ansible.builtin.reboot:
+  become: true
+  when: k3s_install_occurred

--- a/ansible/roles/k3s/tasks/worker.yml
+++ b/ansible/roles/k3s/tasks/worker.yml
@@ -52,10 +52,17 @@
 - name: Install k3s worker node version {{ k3s_version | default('latest') }}
   ansible.builtin.shell: # noqa command-instead-of-shell
     cmd: >
-      INSTALL_K3S_VERSION="{{ k3s_version  | default('') }}"
+      INSTALL_K3S_VERSION="{{ k3s_version | default('') }}"
       K3S_URL="https://{{ k3s_control_plane_ip }}:6443"
       K3S_TOKEN="{{ node_token.stdout }}"
       /tmp/k3s.sh
   become: true
+  register: k3s_installed
   changed_when: true
-  when: not in_cluster
+  when: k3s_force or not in_cluster
+
+- name: Set the k3s_install_occurred fact
+  ansible.builtin.set_fact: # noqa no-handler
+    k3s_install_occurred: true
+  when: k3s_installed.changed
+  changed_when: false

--- a/ansible/roles/k3s/vars/main.yml
+++ b/ansible/roles/k3s/vars/main.yml
@@ -1,2 +1,5 @@
 # force re-install of k3s when true
 k3s_force: false
+
+# set to true if any node has k3s installed during this playbook run
+k3s_install_occurred: false

--- a/ansible/roles/tools/tasks/main.yml
+++ b/ansible/roles/tools/tasks/main.yml
@@ -1,4 +1,10 @@
 # install tools into the execution environment
+- name: Ensure completion folders exist
+  ansible.builtin.file:
+    name: "{{ item.completion_dir }}"
+    state: directory
+    mode: '0755'
+  loop: "{{ tools_shell }}"
 
 - name: Execute the tool task files
   ansible.builtin.include_tasks: |-

--- a/ansible/roles/tools/vars/main.yml
+++ b/ansible/roles/tools/vars/main.yml
@@ -6,10 +6,10 @@ tools_bashrc: "{{ lookup('ansible.builtin.env', 'BASHRC', default='${HOME}/.bash
 tools_shell:
   - name: bash
     rc_file: "{{ tools_bashrc }}"
-    completion_dir: /usr/share/zsh/vendor-completions
+    completion_dir: ~/.local/share/bash-completion
   - name: zsh
     rc_file: "{{ tools_zshrc }}"
-    completion_dir: /usr/share/zsh/vendor-completions
+    completion_dir: ~/.oh-my-zsh/completions
 
 tools_additional_packages:
   - iputils-ping


### PR DESCRIPTION
Because we keep having issues with ingress install stalling on job
ingress-nginx-nginx-admission-patch 