### PR TITLE
Enable OAuth2 proxy

### DIFF
--- a/kubernetes-services/values.yaml
+++ b/kubernetes-services/values.yaml
@@ -38,7 +38,7 @@ llamacpp:
 # OAuth2 authentication gateway.
 # Set to true AFTER completing the OAuth setup guide (docs/how-to/oauth-setup).
 # When false, services are accessible without OAuth authentication.
-enable_oauth2_proxy: false
+enable_oauth2_proxy: true
 
 # Cloudflare Tunnel for web services.
 # Set to true AFTER adding public hostnames in the Cloudflare Zero Trust


### PR DESCRIPTION
## Summary
- Enable `enable_oauth2_proxy` so external traffic is gated by GitHub OAuth before reaching services

## Test plan
- Visit a protected service (e.g. Grafana, Headlamp) from outside the LAN
- Verify redirect to GitHub login via oauth2-proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)