### PR TITLE
Pass repo_branch from root app to child apps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,9 +12,8 @@
 
 - **Playbook tag for packages is `servers`**, not `update_packages`.
   `--tags update_packages` silently does nothing.
-- **Dual `repo_branch`** — must update both `group_vars/all.yml` AND
-  `kubernetes-services/values.yaml` when switching branches. They cannot be
-  unified (Ansible bootstrap vs ArgoCD runtime).
+- **Branch switching** — only edit `group_vars/all.yml` `repo_branch`, then
+  run `--tags cluster`. The root app passes it down to all child apps.
 - **`known_hosts` task must be `serial: 1`** — parallel writes race.
 - **Traefik is disabled** — project uses `--disable=traefik` with NGINX Ingress.
 - **No automated tests** — validate by running playbook tags against the cluster.

--- a/argo-cd/argo-git-repository.yaml
+++ b/argo-cd/argo-git-repository.yaml
@@ -18,11 +18,11 @@ spec:
       {{ repo_branch }}
     helm:
       valuesObject:
-        # pass down details so the child apps are also parameterized
-        # NOTE: repo_branch is intentionally NOT set here - it lives in
-        # kubernetes-services/values.yaml in the repo, so it is always
-        # checked out at the same targetRevision as the root app, making
-        # child app targetRevisions self-referential.
+        # Pass down variables so child apps are also parameterized.
+        # repo_branch is passed here (not read from values.yaml) so that
+        # branch switching only requires changing group_vars/all.yml and
+        # running --tags cluster — no need to push to the target branch.
+        repo_branch: "{{ repo_branch }}"
         repo_remote: "{{ repo_remote }}"
         cluster_domain: "{{ cluster_domain }}"
         domain_email: "{{ domain_email }}"

--- a/docs/how-to/work-in-branches.md
+++ b/docs/how-to/work-in-branches.md
@@ -1,56 +1,55 @@
 # Work in Branches and Forks
 
 ArgoCD tracks a specific Git branch for all cluster services. When developing in
-a feature branch or a fork, you need to ensure ArgoCD syncs the correct branch.
+a feature branch or a fork, you can switch the cluster to track any branch
+without pushing changes to that branch first.
 
 ## How branch propagation works
 
-The root `all-cluster-services` ArgoCD Application deploys the
-`kubernetes-services/` Helm chart. This chart's `values.yaml` contains:
+The root `all-cluster-services` ArgoCD Application is created by Ansible from
+`argo-cd/argo-git-repository.yaml`. It sets `targetRevision` to the value of
+`repo_branch` in `group_vars/all.yml` and passes it down to all child apps via
+`valuesObject`. Child app templates use `{{ .Values.repo_branch }}` for their
+own `targetRevision`.
 
-```yaml
-repo_branch: main
-```
-
-This value is passed to all child Applications as `{{ .Values.repo_branch }}`, which
-they use as their `targetRevision`. Since ArgoCD checks out `values.yaml` at the
-**same** `targetRevision` as the root app, the value is self-referential — whatever
-branch ArgoCD is tracking, it reads the `repo_branch` from that branch's own
-`values.yaml`.
+This means `group_vars/all.yml` is the **single source of truth** for which
+branch the entire cluster tracks.
 
 ## Working in a feature branch
 
-### Step 1: Update `values.yaml` in your branch
-
-Edit `kubernetes-services/values.yaml` on your branch:
+### Step 1: Update `group_vars/all.yml`
 
 ```yaml
 repo_branch: my-feature-branch
 ```
 
-Commit and push this change.
+### Step 2: Apply with the cluster tag
 
-### Step 2: Redeploy with the branch name
+```bash
+ansible-playbook pb_all.yml --tags cluster
+```
+
+This updates the root ArgoCD Application's `targetRevision` and passes the new
+branch to all child apps. No commit or push is needed — the playbook applies
+directly to the cluster.
+
+For a one-off switch without editing the file:
 
 ```bash
 ansible-playbook pb_all.yml --tags cluster -e repo_branch=my-feature-branch
 ```
 
-This updates the root ArgoCD Application's `targetRevision` to your branch.
-
 ### Step 3: Return to main
-
-When done, switch the root app back to `main`:
 
 ```bash
 ansible-playbook pb_all.yml --tags cluster -e repo_branch=main
 ```
 
-And make sure `kubernetes-services/values.yaml` on `main` still says `repo_branch: main`.
+(Or edit `group_vars/all.yml` back to `main` and re-run.)
 
 ## Working in a fork
 
-If you forked the repository, permanently update the remote URL in `group_vars/all.yml`:
+If you forked the repository, update the remote URL in `group_vars/all.yml`:
 
 ```yaml
 repo_remote: https://github.com/your-user/tpi-k3s-ansible.git
@@ -69,20 +68,3 @@ ansible-playbook pb_all.yml --tags cluster \
   -e repo_branch=your_branch \
   -e repo_remote=https://github.com/your-user/tpi-k3s-ansible.git
 ```
-
-## Fixing stale `repo_branch` in the live Application
-
-If you change the root Application's `targetRevision` but the child apps still track
-an old branch, the live Application CR may have an old `repo_branch` baked into its
-`valuesObject` that overrides `values.yaml`. Remove it:
-
-```bash
-kubectl patch application all-cluster-services -n argo-cd --type json \
-  -p '[{"op":"remove","path":"/spec/source/helm/valuesObject/repo_branch"}]'
-```
-
-:::{important}
-Each branch **must** have the correct `repo_branch` value in its own
-`kubernetes-services/values.yaml`. If they disagree, child apps may track the wrong
-branch.
-:::

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -104,22 +104,6 @@ kubectl -n argo-cd delete app <app-name>
 # ArgoCD will re-create it from the parent all-cluster-services app
 ```
 
-### Stale `valuesObject` after branch switch
-
-**Symptom:** ArgoCD child apps still track the old branch after switching
-`targetRevision` in the root app.
-
-**Cause:** A `valuesObject` field in the live Application CR overrides the
-`repo_branch` from `values.yaml`.
-
-**Fix:**
-
-```bash
-kubectl patch application all-cluster-services -n argo-cd --type json \
-  -p '[{"op":"remove","path":"/spec/source/helm/valuesObject/repo_branch"}]'
-```
-
-See [](../how-to/work-in-branches.md) for full details.
 
 ## Browser
 

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -35,9 +35,9 @@ cluster_domain: gkcluster.org # the DNS name for the cluster control plane node
 domain_email: giles.knap@gilesk.gkcluster.org # the email address for letsencrypt
 # where argocd will get the cluster configuration from
 repo_remote: https://github.com/gilesknap/tpi-k3s-ansible.git
-# IMPORTANT: when changing branches, this value AND kubernetes-services/values.yaml
-# repo_branch must both be updated to match (they are consumed by different systems:
-# this file by Ansible bootstrap, values.yaml by ArgoCD Helm at runtime).
+# Single source of truth for branch tracking. Change this and run
+# ansible-playbook pb_all.yml --tags cluster to switch branches.
+# The root app passes this down to all child apps via valuesObject.
 repo_branch: main
 
 # Set nvidia_gpu_node: true in host_vars/<nodename>.yml (or inline in hosts.yml)

--- a/kubernetes-services/values.yaml
+++ b/kubernetes-services/values.yaml
@@ -1,10 +1,6 @@
-# This file is checked out at the same targetRevision as the root app.
-# That means repo_branch here always matches the branch ArgoCD is tracking,
-# so all child app targetRevisions stay in sync automatically when the
-# root app's targetRevision is changed.
-# IMPORTANT: when changing branches, this value AND group_vars/all.yml repo_branch
-# must both be updated to match (they are consumed by different systems:
-# this file by ArgoCD Helm at runtime, all.yml by Ansible bootstrap).
+# repo_branch is injected by the root app's valuesObject (from
+# group_vars/all.yml). This default is only used if the root app
+# does not pass it down (e.g. during local helm template testing).
 repo_branch: main
 
 # NFS storage for RKLLama models — edit these to match your NFS server.


### PR DESCRIPTION
## Summary
- Pass `repo_branch` from the root ArgoCD app to child apps via `valuesObject`
- Eliminates the dual `repo_branch` foot-gun — branch switching now only requires editing `group_vars/all.yml` and running `--tags cluster`
- No need to push to the target branch before switching
- Updated CLAUDE.md, work-in-branches guide, and troubleshooting docs

## Test plan
- [x] Cluster running on this branch — all apps Synced/Healthy
- [ ] Merge to main, switch cluster to main, verify all child apps track main

🤖 Generated with [Claude Code](https://claude.com/claude-code)