### PR TITLE
Switch ArgoCD back to main branch and latest image tag

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -38,7 +38,7 @@ repo_remote: https://github.com/gilesknap/tpi-k3s-ansible.git
 # Single source of truth for branch tracking. Change this and run
 # ansible-playbook pb_all.yml --tags cluster to switch branches.
 # The root app passes this down to all child apps via valuesObject.
-repo_branch: refine-open-brain
+repo_branch: main
 
 # Set nvidia_gpu_node: true in host_vars/<nodename>.yml (or inline in hosts.yml)
 # for any node that has an NVIDIA GPU. This triggers NVIDIA container toolkit

--- a/kubernetes-services/additions/open-brain-mcp/values.yaml
+++ b/kubernetes-services/additions/open-brain-mcp/values.yaml
@@ -1,5 +1,5 @@
 image:
   repository: ghcr.io/gilesknap/open-brain-mcp
-  tag: beta
+  tag: latest
 github_allowed_users: "gilesknap"
 server_url: "https://brain.gkcluster.org"

--- a/kubernetes-services/templates/open-brain-mcp.yaml
+++ b/kubernetes-services/templates/open-brain-mcp.yaml
@@ -20,7 +20,7 @@ spec:
         valuesObject:
           image:
             repository: ghcr.io/gilesknap/open-brain-mcp
-            tag: beta
+            tag: latest
           github_allowed_users: "gilesknap"
           server_url: "https://brain.{{ .Values.cluster_domain }}"
     # Source 2: Reusable ingress sub-chart


### PR DESCRIPTION
## Summary
- Set `repo_branch` back to `main` (was `refine-open-brain`)
- Revert open-brain-mcp image tag from `beta` to `latest`

Post-merge cleanup after PR #182.

🤖 Generated with [Claude Code](https://claude.com/claude-code)