### PR TITLE
Document Ansible k8s annotation merge foot-gun

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,10 @@
 
 ## Foot-Guns
 
+- **Ansible `k8s` module merges annotations** — it never removes annotations
+  that were previously set on an Ingress. If you remove annotations from a
+  template (e.g. `ssl-passthrough`), you must `kubectl delete` the old
+  Ingress first, then re-run the playbook to recreate it cleanly.
 - **Playbook tag for packages is `servers`**, not `update_packages`.
   `--tags update_packages` silently does nothing.
 - **Branch switching** — only edit `group_vars/all.yml` `repo_branch`, then


### PR DESCRIPTION
## Summary

- Add foot-gun warning to CLAUDE.md: Ansible's `k8s` module merges annotations but never removes them. Removing annotations from a template requires deleting the old Ingress first, then re-running the playbook.

Discovered during the ArgoCD tunnel migration when stale `ssl-passthrough` annotations persisted after updating the template.

## Test plan

- [x] Read-only change to CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)