### PR TITLE
Fix Dex docs and seal-argocd-dex pod restarts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,18 @@
   oauth2-proxy. Use `secrets.token_hex(16)` (32 hex chars = 32 bytes).
   This bug has been fixed and regressed before — do not change the
   cookie-secret generation in `scripts/seal-argocd-dex`.
+- **Re-sealing secrets requires pod restarts** — `seal-argocd-dex` now
+  restarts affected pods automatically. If you re-seal secrets manually
+  or via a different path, you must restart pods in `argocd-monitor`,
+  `monitoring` (grafana), `open-webui`, and `headlamp` namespaces.
+  Env vars from K8s Secrets are snapshot-at-startup; running pods keep
+  stale values until restarted.
+- **DEX duplicate `argo-cd` static client** — ArgoCD auto-generates an
+  `argo-cd` DEX client (without `trustedPeers`). Our `dex.config` also
+  declares one (with `trustedPeers: [argocd-monitor]`). DEX v2.45+
+  stores the first and drops the duplicate, so `trustedPeers` never
+  takes effect. This causes a "Grant Access" approval screen for
+  argocd-monitor. Cannot be fixed without upstream ArgoCD changes.
 - **Playbook tag for packages is `servers`**, not `update_packages`.
   `--tags update_packages` silently does nothing.
 - **Branch switching** — use `just switch-branch <branch>` to point the

--- a/kubernetes-services/additions/argocd/README.md
+++ b/kubernetes-services/additions/argocd/README.md
@@ -53,11 +53,19 @@ the `argo-cd` audience so ArgoCD's API accepts them.
 ArgoCD auto-generates Dex static clients (`argo-cd`, `argo-cd-cli`,
 `argo-cd-pkce`) at the start of the client list. Custom clients from
 `dex.config` in `argocd-cm` are appended **after** them. When duplicate client
-IDs exist, the **last entry wins**.
+IDs exist, the **first entry wins** — DEX v2.45+ memory storage rejects
+duplicates with `ErrAlreadyExists` and keeps the original.
 
-We override the `argo-cd` client in `dex.config` to add
-`trustedPeers: [argocd-monitor]`. The `argocd-monitor` oauth2-proxy requests
-scope `audience:server:client_id:argo-cd`, so the Dex token has the `argo-cd`
+We declare an `argo-cd` client in `dex.config` with
+`trustedPeers: [argocd-monitor]`, but because the auto-generated `argo-cd`
+entry (without `trustedPeers`) is stored first, our override is silently
+dropped. As a result, DEX shows a "Grant Access" approval screen for
+argocd-monitor's cross-client auth flow. This is cosmetic (one extra click)
+and cannot be fixed without upstream ArgoCD changes to either suppress
+auto-generated clients or support `trustedPeers` on them.
+
+The `argocd-monitor` oauth2-proxy requests scope
+`audience:server:client_id:argo-cd`, so the Dex token has the `argo-cd`
 audience that ArgoCD accepts.
 
 ### Why not `server.additional.audiences`?

--- a/scripts/seal-argocd-dex
+++ b/scripts/seal-argocd-dex
@@ -77,3 +77,19 @@ kubectl create secret generic headlamp-oidc-secret \
   --from-literal=OIDC_SCOPES="openid profile email" \
   --dry-run=client -o yaml | seal_to kubernetes-services/additions/dashboard/templates/headlamp-oidc-secret.yaml
 echo "Sealed: kubernetes-services/additions/dashboard/templates/headlamp-oidc-secret.yaml"
+
+# Restart pods that read secrets via env vars (env vars are snapshot-at-startup).
+# Without this, pods keep stale client-secret values after re-sealing.
+echo ""
+echo "Restarting pods that reference re-sealed secrets..."
+for ns_deploy in argocd-monitor/argocd-monitor monitoring/grafana-prometheus-grafana open-webui/open-webui headlamp/headlamp; do
+  ns="${ns_deploy%%/*}"
+  deploy="${ns_deploy##*/}"
+  if kubectl get deployment "$deploy" -n "$ns" &>/dev/null; then
+    kubectl rollout restart deployment "$deploy" -n "$ns"
+    echo "  Restarted $ns/$deploy"
+  else
+    echo "  Skipped $ns/$deploy (not found)"
+  fi
+done
+echo "Done. DEX server is restarted separately by 'ansible-playbook --tags cluster'."


### PR DESCRIPTION
## Summary

- **Dex duplicate client docs**: corrected README to reflect that DEX v2.45+ keeps the first entry (not last), so our `trustedPeers` override is silently dropped
- **seal-argocd-dex restarts**: script now restarts pods that read secrets via env vars after re-sealing, preventing stale client secrets
- **CLAUDE.md foot-guns**: added notes about re-sealing requiring pod restarts, and the Dex duplicate client limitation

## Test plan

- [x] `seal-argocd-dex` script runs and restarts pods
- [x] Docs accurately describe current Dex behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)