### PR TITLE
Fix argocd-monitor oauth2-proxy: bump to 0.5.2 and add --api-route

### DIFF
--- a/kubernetes-services/templates/argocd-monitor.yaml
+++ b/kubernetes-services/templates/argocd-monitor.yaml
@@ -34,6 +34,7 @@ spec:
               - --redirect-url=https://argocd-monitor.{{ .Values.cluster_domain }}/oauth2/callback
               - --scope=openid profile email audience:server:client_id:argo-cd
               - --cookie-name=_oauth2_proxy_monitor
+              - --api-route=/api/
 
     - path: ./kubernetes-services/additions/argocd-monitor
       repoURL: {{ .Values.repo_remote }}


### PR DESCRIPTION
## Summary
- Bump argocd-monitor chart to 0.5.2 (frontend auth failure handling)
- Add `--api-route=/api/` so oauth2-proxy returns 401 instead of 302 for API paths

When Dex restarts (in-memory storage), all OAuth sessions are invalidated. Previously, oauth2-proxy returned 302 redirects for expired API requests, which `fetch()` couldn't follow cross-origin — the UI got stuck showing errors until cookies were manually cleared. Now oauth2-proxy returns 401, and the 0.5.2 frontend detects this and redirects the browser for transparent re-authentication.

## Test plan
- [x] All 8 cluster services pass OAuth flow verification
- [x] argocd-monitor recovers from auth failure without manual cookie clearing

🤖 Generated with [Claude Code](https://claude.com/claude-code)