### PR TITLE
Remove Dex Grant Access screen for argocd-monitor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,8 +44,11 @@
   `argo-cd` DEX client (without `trustedPeers`). Our `dex.config` also
   declares one (with `trustedPeers: [argocd-monitor]`). DEX v2.45+
   stores the first and drops the duplicate, so `trustedPeers` never
-  takes effect. This causes a "Grant Access" approval screen for
-  argocd-monitor. Cannot be fixed without upstream ArgoCD changes.
+  takes effect. Fixed by adding `oidc.config` with
+  `allowedAudiences: [argo-cd, argocd-monitor]` in PR #297, which
+  lets argocd-monitor authenticate as itself (no cross-client scope).
+  The duplicate `argo-cd` client in `dex.config` is harmless but
+  redundant — kept for clarity about the intended `trustedPeers`.
 - **Playbook tag for packages is `servers`**, not `update_packages`.
   `--tags update_packages` silently does nothing.
 - **Branch switching** — use `just switch-branch <branch>` to point the

--- a/kubernetes-services/templates/argocd-monitor.yaml
+++ b/kubernetes-services/templates/argocd-monitor.yaml
@@ -32,9 +32,10 @@ spec:
             existingSecret: argocd-monitor-oauth
             extraArgs:
               - --redirect-url=https://argocd-monitor.{{ .Values.cluster_domain }}/oauth2/callback
-              - --scope=openid profile email audience:server:client_id:argo-cd
+              - --scope=openid profile email
               - --cookie-name=_oauth2_proxy_monitor
               - --api-route=/api/
+              - --prompt=login
 
     - path: ./kubernetes-services/additions/argocd-monitor
       repoURL: {{ .Values.repo_remote }}

--- a/roles/cluster/tasks/argocd.yml
+++ b/roles/cluster/tasks/argocd.yml
@@ -54,6 +54,18 @@
         cm:
           url: "https://argocd.{{ cluster_domain }}"
           admin.enabled: "false"
+          oidc.config: |
+            name: Dex
+            issuer: https://argocd.{{ cluster_domain }}/api/dex
+            clientID: argo-cd
+            clientSecret: {{ _argocd_dex_client_secret }}
+            allowedAudiences:
+              - argo-cd
+              - argocd-monitor
+            requestedScopes:
+              - openid
+              - profile
+              - email
           dex.config: |
             connectors:
               - type: github


### PR DESCRIPTION
## Summary
- Add `oidc.config` with `allowedAudiences: [argo-cd, argocd-monitor]` to ArgoCD
- Remove cross-client `audience:server:client_id:argo-cd` scope from oauth2-proxy
- Add `--prompt=login` to suppress legacy `approval_prompt=force` default
- Update CLAUDE.md foot-gun entry

## Root cause
The Dex "Grant Access" approval screen appeared on every argocd-monitor login due to two issues:

1. **oauth2-proxy sends `approval_prompt=force`** by default, overriding Dex's `skipApprovalScreen:true`. `--approval-prompt=` (empty) doesn't clear it. `--prompt=login` sends the OIDC-standard `prompt=login` instead, which suppresses the legacy parameter.

2. **Cross-client auth required `trustedPeers`** on the `argo-cd` Dex client, but ArgoCD auto-generates this client without `trustedPeers`, shadowing our config. Adding `oidc.config` with `allowedAudiences` lets ArgoCD accept `argocd-monitor`-audience tokens directly, eliminating the need for cross-client auth entirely.

## Test plan
- [x] All 8 cluster services pass OAuth flow verification
- [x] Dex Grant Access screen no longer appears (verified with full GitHub logout/login)
- [x] ArgoCD login still works with `oidc.config`

🤖 Generated with [Claude Code](https://claude.com/claude-code)