### PR TITLE
Add Alertmanager ingress with OAuth and Slack alerts

### DIFF
--- a/kubernetes-services/additions/grafana/alertmanager-slack-secret.yaml
+++ b/kubernetes-services/additions/grafana/alertmanager-slack-secret.yaml
@@ -1,0 +1,14 @@
+# Placeholder — run `scripts/seal-argocd-dex` to generate the real SealedSecret.
+# Must be *-secret.yaml (singular) to match .gitleaks.toml allowlist.
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: alertmanager-slack-secret
+  namespace: monitoring
+spec:
+  encryptedData:
+    webhook-url: REPLACE_ME
+  template:
+    metadata:
+      name: alertmanager-slack-secret
+      namespace: monitoring

--- a/kubernetes-services/additions/home/templates/manifests.yaml
+++ b/kubernetes-services/additions/home/templates/manifests.yaml
@@ -162,6 +162,10 @@ data:
           <h2>Supabase Studio<span class="badge badge-oauth">OAuth</span></h2>
           <p>Database and backend management</p>
         </a>
+        <a class="card" href="https://alertmanager.{{ .Values.cluster_domain }}">
+          <h2>Alertmanager<span class="badge badge-oauth">OAuth</span></h2>
+          <p>Alert routing and notification management</p>
+        </a>
         <a class="card" href="https://argocd-monitor.{{ .Values.cluster_domain }}">
           <h2>ArgoCD Monitor<span class="badge badge-sso">SSO</span></h2>
           <p>Application health monitoring</p>

--- a/kubernetes-services/templates/grafana.yaml
+++ b/kubernetes-services/templates/grafana.yaml
@@ -114,12 +114,44 @@ spec:
                               - ws03
 
           alertmanager:
+            ingress:
+              enabled: true
+              ingressClassName: nginx
+              annotations:
+                nginx.ingress.kubernetes.io/auth-url: "http://oauth2-proxy.oauth2-proxy.svc.cluster.local/oauth2/auth"
+                nginx.ingress.kubernetes.io/auth-signin: "https://oauth2.{{ .Values.cluster_domain }}/oauth2/start?rd=https://$host$escaped_request_uri"
+                nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User,X-Auth-Request-Email"
+{{- if .Values.enable_cloudflare_tunnel }}
+                nginx.ingress.kubernetes.io/ssl-redirect: "false"
+{{- end }}
+              hosts:
+                - alertmanager.{{ .Values.cluster_domain }}
+              tls:
+                - hosts:
+                    - alertmanager.{{ .Values.cluster_domain }}
             alertmanagerSpec:
               tolerations:
                 - key: workstation
                   operator: Equal
                   value: "true"
                   effect: NoSchedule
+              secrets:
+                - alertmanager-slack-secret
+            config:
+              route:
+                receiver: slack
+                group_by:
+                  - alertname
+                  - namespace
+                group_wait: 30s
+                group_interval: 5m
+                repeat_interval: 4h
+              receivers:
+                - name: slack
+                  slack_configs:
+                    - channel: '#alerts'
+                      send_resolved: true
+                      api_url_file: /etc/alertmanager/secrets/alertmanager-slack-secret/webhook-url
 
           prometheusOperator:
             admissionWebhooks:

--- a/scripts/seal-argocd-dex
+++ b/scripts/seal-argocd-dex
@@ -65,3 +65,15 @@ kubectl create secret generic open-webui-oauth-secret \
   --from-literal=client-secret="$openwebui_secret" \
   --dry-run=client -o yaml | seal_to kubernetes-services/additions/open-webui/open-webui-oauth-secret.yaml
 echo "Sealed: kubernetes-services/additions/open-webui/open-webui-oauth-secret.yaml"
+# Alertmanager Slack webhook secret
+slack_webhook="${SLACK_WEBHOOK_URL:-}"
+if [ -z "$slack_webhook" ]; then read -p "Slack Webhook URL (blank to skip): " slack_webhook < /dev/tty; fi
+if [ -n "$slack_webhook" ]; then
+  kubectl create secret generic alertmanager-slack-secret \
+    --namespace monitoring \
+    --from-literal=webhook-url="$slack_webhook" \
+    --dry-run=client -o yaml | seal_to kubernetes-services/additions/grafana/alertmanager-slack-secret.yaml
+  echo "Sealed: kubernetes-services/additions/grafana/alertmanager-slack-secret.yaml"
+else
+  echo "Skipped: alertmanager-slack-secret (no webhook URL provided)"
+fi


### PR DESCRIPTION
## Summary
- Expose Alertmanager via NGINX ingress with shared oauth2-proxy auth (same pattern as Headlamp/Longhorn)
- Configure Slack alerting to `#alerts` channel via sealed webhook secret
- Add Alertmanager card to the cluster landing page
- Add Slack webhook sealing to `seal-argocd-dex` script (skippable if no URL provided)

## Test plan
- [x] ArgoCD syncs successfully
- [x] `kubectl get ingress -n monitoring` shows alertmanager ingress with oauth2-proxy annotations
- [x] `https://alertmanager.gkcluster.org` redirects to GitHub OAuth and loads Alertmanager UI
- [x] Landing page shows Alertmanager card with OAuth badge
- [ ] After sealing Slack webhook: trigger test alert and verify delivery to `#alerts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)