### PR TITLE
Fix Alertmanager null receiver + seal-script params

### DIFF
--- a/justfile
+++ b/justfile
@@ -104,9 +104,10 @@ extract-secrets output_dir="/tmp/cluster-secrets":
 seal-from-json json_file:
     scripts/seal-from-json {{ json_file }}
 
-# Seal all Dex-related secrets (argocd-dex, monitor, grafana, open-webui oauth)
-seal-argocd-dex:
-    scripts/seal-argocd-dex
+# Seal Dex-related secrets. No arg = all; otherwise one of:
+# github, argocd, monitor, grafana, open-webui, slack (see scripts/seal-argocd-dex help)
+seal-argocd-dex target="":
+    scripts/seal-argocd-dex {{ target }}
 
 # Generate all secrets fresh and seal in one step (for rebuild)
 generate-and-seal-all output_dir="/tmp/cluster-secrets":

--- a/kubernetes-services/additions/grafana/alertmanager-slack-secret.yaml
+++ b/kubernetes-services/additions/grafana/alertmanager-slack-secret.yaml
@@ -1,5 +1,4 @@
-# Placeholder — run `scripts/seal-argocd-dex` to generate the real SealedSecret.
-# Must be *-secret.yaml (singular) to match .gitleaks.toml allowlist.
+---
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:
@@ -7,7 +6,7 @@ metadata:
   namespace: monitoring
 spec:
   encryptedData:
-    webhook-url: REPLACE_ME
+    webhook-url: AgBrXKu4vvs8Z1Y7B+SUdnF5YZoFPXbjhx91lIIz2HJsNJ0p1gDj0ezgE9eIJyYrA5c+P3pirjY7MenEjZnFj1VJBCm8ltYKrRwy9u6MWdturRyUcCMHCCWrrk4g7nmzIWE7bzHcvBDKCX7zaYUXuDyw5CcC70CkctopBluzKP7BEF0UTOQsuW7WSuLZtEkmy9HA04ZHBE1Uj7PiDDvIwR7r232Eha7uZg0kfokcO/SJR1fC2aP0tS0iyw+rv7HBqxuuLR8RC+4JlYt6cyTuE4i0EXvxzFTpa+O48n4kAue9Qz7VFLzZLEEOGX6o3+kq5ngmrJSBvJtOFFdsRvTPdF5r12nqHx45YqG2zYUNPtxWpUzuTIzUZ6NJKIYpYiCRKxhQ3LtsyGhD+18G6QLkXVj5fn1xnZa5g+akrV9YcaF6oLPOz3Wx+26QU+oyQP1n1xlG7dGUo/CxmH9qeeLjgTuu1IUM57RVX04MgZBKD+CEwaDg8SfpN6331Z9f82KiGeq1sRMz+sa/RAtAmwGJO4G3lYOCVOvD5ZIr0C06j1ruptJ5aYv64QnUTDNWQ/i3rBnkN1KVF65cX9Rl0nmTo7m0ROymwjj/esBsIE8/d+lxummUgeinDWhVJdbK+xSPCSzGWUuaRDVLt74TnLPGiSUC0ffGP79f/9GgAQ10gqsBrEL+kCKZG2Ofk+m19EnGqVC5LMDRFY8BAZAZV4rGk6esU7cNmzDvyRJJnVthuaTAUA1bcAeGJsN2wyDmXf/y0ajInquqU4dj4ZFW0aislGaho6wdP+tAFLkO8EctJ/4BbgM=
   template:
     metadata:
       name: alertmanager-slack-secret

--- a/kubernetes-services/templates/grafana.yaml
+++ b/kubernetes-services/templates/grafana.yaml
@@ -152,6 +152,11 @@ spec:
                     - channel: '#alerts'
                       send_resolved: true
                       api_url_file: /etc/alertmanager/secrets/alertmanager-slack-secret/webhook-url
+                # Required by the chart-default Watchdog sub-route, which Helm
+                # preserves because route is a dict (deep-merged) while
+                # receivers is a list (replaced). Dropping this re-breaks
+                # Alertmanager reconciliation with "undefined receiver null".
+                - name: "null"
 
           prometheusOperator:
             admissionWebhooks:

--- a/scripts/seal-argocd-dex
+++ b/scripts/seal-argocd-dex
@@ -1,12 +1,32 @@
 #!/bin/bash
-# Seal all Dex-related secrets: argocd-dex-secret (all static client
-# secrets), argocd-monitor oauth2-proxy, grafana-oauth, open-webui-oauth.
-# Reads GITHUB_CLIENT_ID/SECRET from env or prompts interactively.
+# Seal Dex-related secrets. With no arguments, seals everything (original
+# behavior): prompts for GitHub OAuth creds + Slack webhook, generates all
+# Dex static client secrets, and writes all SealedSecret files.
+#
+# Subcommands re-seal a single logical secret without the full prompt set.
+# Partial subcommands that touch argocd-dex-secret read existing keys from
+# the running secret to preserve values they don't touch:
+#
+#   github      Prompt for GitHub OAuth Client ID/Secret, update argocd-dex-secret
+#   argocd      Re-derive argo-cd client secret from server.secretkey
+#   monitor     Rotate argocd-monitor client + cookie secrets
+#   grafana     Rotate grafana client secret
+#   open-webui  Rotate open-webui client secret
+#   slack       Re-seal alertmanager Slack webhook (standalone, not in argocd-dex-secret)
+#
 # The argo-cd client secret is auto-derived from server.secretkey so it
-# matches ArgoCD's internal value. All Dex static client secrets are
-# generated and stored in argocd-dex-secret so $secret:key resolution works.
+# matches ArgoCD's internal value. All Dex static client secrets are stored
+# in argocd-dex-secret so $secret:key resolution works.
 set -euo pipefail
+
 SEAL="kubeseal --controller-name sealed-secrets --controller-namespace kube-system --format yaml"
+
+DEX_SECRET_FILE=kubernetes-services/additions/argocd/argocd-dex-secret.yaml
+MONITOR_SECRET_FILE=kubernetes-services/additions/argocd-monitor/argocd-monitor-oauth-secret.yaml
+GRAFANA_SECRET_FILE=kubernetes-services/additions/grafana/grafana-oauth-secret.yaml
+OPENWEBUI_SECRET_FILE=kubernetes-services/additions/open-webui/open-webui-oauth-secret.yaml
+SLACK_SECRET_FILE=kubernetes-services/additions/grafana/alertmanager-slack-secret.yaml
+
 # Atomic seal: write to temp file, move on success. Prevents truncating
 # existing sealed secrets when kubeseal fails (e.g. controller not ready).
 seal_to() {
@@ -20,60 +40,183 @@ seal_to() {
         exit 1
     fi
 }
-client_id="${GITHUB_CLIENT_ID:-}"
-client_secret="${GITHUB_CLIENT_SECRET:-}"
-if [ -z "$client_id" ]; then read -p "GitHub OAuth Client ID: " client_id < /dev/tty; fi
-if [ -z "$client_secret" ]; then read -sp "GitHub OAuth Client Secret: " client_secret < /dev/tty && echo; fi
-# argo-cd client secret: SHA256(server.secretkey as base64 string) → base64url[:40]
-argocd_client_secret=$(kubectl get secret argocd-secret -n argo-cd \
-    -o jsonpath='{.data.server\.secretkey}' | base64 -d | \
-    python3 -c "import sys,hashlib,base64; print(base64.urlsafe_b64encode(hashlib.sha256(sys.stdin.read().encode()).digest()).decode()[:40])")
-monitor_secret=$(python3 -c "import secrets; print(secrets.token_hex(16))")
-cookie_secret=$(python3 -c "import secrets; print(secrets.token_hex(16))")  # 32 hex chars = 32 bytes, valid for AES-256
-grafana_secret=$(python3 -c "import secrets; print(secrets.token_hex(16))")
-openwebui_secret=$(python3 -c "import secrets; print(secrets.token_hex(16))")
-# Dex secret (argo-cd namespace) — GitHub OAuth + ALL static client secrets
-kubectl create secret generic argocd-dex-secret \
-  --namespace argo-cd \
-  --from-literal=dex.github.clientID="$client_id" \
-  --from-literal=dex.github.clientSecret="$client_secret" \
-  --from-literal=argo-cd.clientSecret="$argocd_client_secret" \
-  --from-literal=argocd.clientSecret="$argocd_client_secret" \
-  --from-literal=argocd-monitor.clientSecret="$monitor_secret" \
-  --from-literal=grafana.clientSecret="$grafana_secret" \
-  --from-literal=open-webui.clientSecret="$openwebui_secret" \
-  --dry-run=client -o yaml | \
-  yq '.metadata.labels["app.kubernetes.io/part-of"] = "argocd"' | \
-  seal_to kubernetes-services/additions/argocd/argocd-dex-secret.yaml
-echo "Sealed: kubernetes-services/additions/argocd/argocd-dex-secret.yaml"
-# argocd-monitor oauth2-proxy secret
-kubectl create secret generic argocd-monitor-oauth \
-  --namespace argocd-monitor \
-  --from-literal=client-secret="$monitor_secret" \
-  --from-literal=cookie-secret="$cookie_secret" \
-  --dry-run=client -o yaml | seal_to kubernetes-services/additions/argocd-monitor/argocd-monitor-oauth-secret.yaml
-echo "Sealed: kubernetes-services/additions/argocd-monitor/argocd-monitor-oauth-secret.yaml"
-# Grafana OAuth secret — key must be CLIENT_SECRET (loaded via envFromSecrets)
-kubectl create secret generic grafana-oauth-secret \
-  --namespace monitoring \
-  --from-literal=CLIENT_SECRET="$grafana_secret" \
-  --dry-run=client -o yaml | seal_to kubernetes-services/additions/grafana/grafana-oauth-secret.yaml
-echo "Sealed: kubernetes-services/additions/grafana/grafana-oauth-secret.yaml"
-# Open WebUI OAuth secret — key must be client-secret (loaded via secretKeyRef)
-kubectl create secret generic open-webui-oauth-secret \
-  --namespace open-webui \
-  --from-literal=client-secret="$openwebui_secret" \
-  --dry-run=client -o yaml | seal_to kubernetes-services/additions/open-webui/open-webui-oauth-secret.yaml
-echo "Sealed: kubernetes-services/additions/open-webui/open-webui-oauth-secret.yaml"
-# Alertmanager Slack webhook secret
-slack_webhook="${SLACK_WEBHOOK_URL:-}"
-if [ -z "$slack_webhook" ]; then read -p "Slack Webhook URL (blank to skip): " slack_webhook < /dev/tty; fi
-if [ -n "$slack_webhook" ]; then
-  kubectl create secret generic alertmanager-slack-secret \
-    --namespace monitoring \
-    --from-literal=webhook-url="$slack_webhook" \
-    --dry-run=client -o yaml | seal_to kubernetes-services/additions/grafana/alertmanager-slack-secret.yaml
-  echo "Sealed: kubernetes-services/additions/grafana/alertmanager-slack-secret.yaml"
-else
-  echo "Skipped: alertmanager-slack-secret (no webhook URL provided)"
-fi
+
+# Read a dotted key from the running argocd-dex-secret (base64-decoded).
+# The caller must backslash-escape dots so jsonpath treats them as literal.
+get_dex_key() {
+    kubectl get secret argocd-dex-secret -n argo-cd \
+        -o jsonpath="{.data.$1}" 2>/dev/null | base64 -d
+}
+
+require_existing_dex_secret() {
+    if ! kubectl get secret argocd-dex-secret -n argo-cd >/dev/null 2>&1; then
+        echo "ERROR: argocd-dex-secret not found in argo-cd namespace." >&2
+        echo "Run '$0' with no arguments first to seal everything." >&2
+        exit 1
+    fi
+}
+
+prompt_github() {
+    client_id="${GITHUB_CLIENT_ID:-}"
+    client_secret="${GITHUB_CLIENT_SECRET:-}"
+    if [ -z "$client_id" ]; then read -p "GitHub OAuth Client ID: " client_id < /dev/tty; fi
+    if [ -z "$client_secret" ]; then read -sp "GitHub OAuth Client Secret: " client_secret < /dev/tty && echo; fi
+}
+
+# base64url(SHA256(server.secretkey))[:40] — matches ArgoCD's internal value
+derive_argocd_client_secret() {
+    kubectl get secret argocd-secret -n argo-cd \
+        -o jsonpath='{.data.server\.secretkey}' | base64 -d | \
+        python3 -c "import sys,hashlib,base64; print(base64.urlsafe_b64encode(hashlib.sha256(sys.stdin.read().encode()).digest()).decode()[:40])"
+}
+
+# 32 hex chars = 32 bytes, valid for AES-256 (oauth2-proxy cookie-secret
+# requires exactly 16, 24, or 32 bytes — see CLAUDE.md foot-guns)
+rand_hex32() {
+    python3 -c "import secrets; print(secrets.token_hex(16))"
+}
+
+# Re-seal argocd-dex-secret. Any of the following variables that are unset
+# or empty are populated from the currently-running secret in the cluster:
+#   client_id client_secret argocd_client_secret
+#   monitor_secret grafana_secret openwebui_secret
+seal_dex_secret() {
+    : "${client_id:=$(get_dex_key 'dex\.github\.clientID')}"
+    : "${client_secret:=$(get_dex_key 'dex\.github\.clientSecret')}"
+    : "${argocd_client_secret:=$(get_dex_key 'argo-cd\.clientSecret')}"
+    : "${monitor_secret:=$(get_dex_key 'argocd-monitor\.clientSecret')}"
+    : "${grafana_secret:=$(get_dex_key 'grafana\.clientSecret')}"
+    : "${openwebui_secret:=$(get_dex_key 'open-webui\.clientSecret')}"
+
+    kubectl create secret generic argocd-dex-secret \
+      --namespace argo-cd \
+      --from-literal=dex.github.clientID="$client_id" \
+      --from-literal=dex.github.clientSecret="$client_secret" \
+      --from-literal=argo-cd.clientSecret="$argocd_client_secret" \
+      --from-literal=argocd.clientSecret="$argocd_client_secret" \
+      --from-literal=argocd-monitor.clientSecret="$monitor_secret" \
+      --from-literal=grafana.clientSecret="$grafana_secret" \
+      --from-literal=open-webui.clientSecret="$openwebui_secret" \
+      --dry-run=client -o yaml | \
+      yq '.metadata.labels["app.kubernetes.io/part-of"] = "argocd"' | \
+      seal_to "$DEX_SECRET_FILE"
+    echo "Sealed: $DEX_SECRET_FILE"
+}
+
+# Re-seal argocd-monitor-oauth. Uses $monitor_secret if set, otherwise
+# generates a fresh one. Cookie-secret is always regenerated.
+seal_monitor_secret() {
+    : "${monitor_secret:=$(rand_hex32)}"
+    local cookie_secret
+    cookie_secret=$(rand_hex32)
+    kubectl create secret generic argocd-monitor-oauth \
+      --namespace argocd-monitor \
+      --from-literal=client-secret="$monitor_secret" \
+      --from-literal=cookie-secret="$cookie_secret" \
+      --dry-run=client -o yaml | seal_to "$MONITOR_SECRET_FILE"
+    echo "Sealed: $MONITOR_SECRET_FILE"
+}
+
+# Key must be CLIENT_SECRET (loaded via envFromSecrets)
+seal_grafana_secret() {
+    : "${grafana_secret:=$(rand_hex32)}"
+    kubectl create secret generic grafana-oauth-secret \
+      --namespace monitoring \
+      --from-literal=CLIENT_SECRET="$grafana_secret" \
+      --dry-run=client -o yaml | seal_to "$GRAFANA_SECRET_FILE"
+    echo "Sealed: $GRAFANA_SECRET_FILE"
+}
+
+# Key must be client-secret (loaded via secretKeyRef)
+seal_openwebui_secret() {
+    : "${openwebui_secret:=$(rand_hex32)}"
+    kubectl create secret generic open-webui-oauth-secret \
+      --namespace open-webui \
+      --from-literal=client-secret="$openwebui_secret" \
+      --dry-run=client -o yaml | seal_to "$OPENWEBUI_SECRET_FILE"
+    echo "Sealed: $OPENWEBUI_SECRET_FILE"
+}
+
+# Seal alertmanager Slack webhook. $require controls behavior on blank input:
+#   "required" (partial subcommand) → error on blank
+#   "optional" (all path)           → skip silently on blank
+seal_slack_secret() {
+    local require="${1:-optional}"
+    local slack_webhook="${SLACK_WEBHOOK_URL:-}"
+    if [ -z "$slack_webhook" ]; then
+        if [ "$require" = "required" ]; then
+            read -p "Slack Webhook URL: " slack_webhook < /dev/tty
+        else
+            read -p "Slack Webhook URL (blank to skip): " slack_webhook < /dev/tty
+        fi
+    fi
+    if [ -z "$slack_webhook" ]; then
+        if [ "$require" = "required" ]; then
+            echo "ERROR: Slack Webhook URL is required" >&2
+            exit 1
+        fi
+        echo "Skipped: alertmanager-slack-secret (no webhook URL provided)"
+        return 0
+    fi
+    kubectl create secret generic alertmanager-slack-secret \
+      --namespace monitoring \
+      --from-literal=webhook-url="$slack_webhook" \
+      --dry-run=client -o yaml | seal_to "$SLACK_SECRET_FILE"
+    echo "Sealed: $SLACK_SECRET_FILE"
+}
+
+cmd="${1:-all}"
+
+case "$cmd" in
+    all)
+        prompt_github
+        argocd_client_secret=$(derive_argocd_client_secret)
+        monitor_secret=$(rand_hex32)
+        grafana_secret=$(rand_hex32)
+        openwebui_secret=$(rand_hex32)
+        seal_dex_secret
+        seal_monitor_secret
+        seal_grafana_secret
+        seal_openwebui_secret
+        seal_slack_secret optional
+        ;;
+    github)
+        require_existing_dex_secret
+        prompt_github
+        seal_dex_secret
+        ;;
+    argocd)
+        require_existing_dex_secret
+        argocd_client_secret=$(derive_argocd_client_secret)
+        seal_dex_secret
+        ;;
+    monitor)
+        require_existing_dex_secret
+        monitor_secret=$(rand_hex32)
+        seal_dex_secret
+        seal_monitor_secret
+        ;;
+    grafana)
+        require_existing_dex_secret
+        grafana_secret=$(rand_hex32)
+        seal_dex_secret
+        seal_grafana_secret
+        ;;
+    open-webui)
+        require_existing_dex_secret
+        openwebui_secret=$(rand_hex32)
+        seal_dex_secret
+        seal_openwebui_secret
+        ;;
+    slack)
+        seal_slack_secret required
+        ;;
+    -h|--help|help)
+        sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
+        exit 0
+        ;;
+    *)
+        echo "Usage: $0 [all|github|argocd|monitor|grafana|open-webui|slack]" >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary
- Add missing `null` receiver to Alertmanager config so the chart-default Watchdog sub-route resolves. Without it Alertmanager refused to load the config (`undefined receiver "null" used in route`) and grafana-prometheus went Degraded in ArgoCD.
- Parameterize `scripts/seal-argocd-dex`.
- Add Slack webhook URL wiring.

## Test plan
- [x] Pre-commit hooks green
- [ ] After merge + ArgoCD sync, confirm `kubectl get alertmanager -n monitoring` shows `Reconciled=True` and grafana-prometheus app reports Healthy