### PR TITLE
Document Alertmanager Slack alerts and seal-argocd-dex subcommands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,21 @@
   that were previously set on an Ingress. If you remove annotations from a
   template (e.g. `ssl-passthrough`), you must `kubectl delete` the old
   Ingress first, then re-run the playbook to recreate it cleanly.
+- **SealedSecret placeholders must use valid base64** — never commit a
+  `*-secret.yaml` with placeholder text like `REPLACE_ME` in
+  `encryptedData`. The sealed-secrets controller fails to decrypt
+  (`illegal base64 data`), the real Secret never gets created, and any
+  Prometheus operator CR (Alertmanager/Prometheus) referencing it via
+  `secrets:` silently omits the volume mount. Always seal a real value
+  immediately, or omit the file entirely until you have one.
+- **`scripts/seal-argocd-dex` has per-secret subcommands** — running
+  it bare (or with `all`) re-seals everything and prompts for GitHub
+  creds + Slack webhook. To rotate just one secret without re-entering
+  unrelated values, use a subcommand:
+  `seal-argocd-dex [github|argocd|monitor|grafana|open-webui|slack]`.
+  Subcommands read existing keys from the running `argocd-dex-secret`
+  to preserve values they don't touch, so `all` must have been run
+  at least once before.
 - **oauth2-proxy `email_domains` must be `[]`** — the Helm chart defaults
   to `email_domains = ["*"]`, which allows any GitHub user through and
   silently overrides `authenticatedEmailsFile`. The fix is

--- a/docs/how-to/manage-sealed-secrets.md
+++ b/docs/how-to/manage-sealed-secrets.md
@@ -38,6 +38,7 @@ These secrets are created during the setup guides:
 | `cloudflared-credentials` | `cloudflared` | Cloudflare tunnel token | additions/cloudflared/tunnel-secret.yaml |
 | `cloudflare-api-token` | `cert-manager` | DNS-01 API token | additions/cert-manager/templates/cloudflare-api-token-secret.yaml |
 | `oauth2-proxy-secret` | `oauth2-proxy` | OAuth2 cookie + client secrets | additions/oauth2-proxy/oauth2-proxy-secret.yaml |
+| `alertmanager-slack-secret` | `monitoring` | Alertmanager Slack webhook URL | additions/grafana/alertmanager-slack-secret.yaml |
 
 ## Prerequisites
 
@@ -100,6 +101,66 @@ git push
 ```
 
 ArgoCD syncs the SealedSecret automatically.
+
+## The `seal-argocd-dex` recipe
+
+`scripts/seal-argocd-dex` seals all authentication-related secrets and
+supports both a one-shot bootstrap mode and per-secret subcommands for
+rotation.
+
+### Secrets it manages
+
+| Secret | Namespace | Subcommand | Source |
+|--------|-----------|------------|--------|
+| `argocd-dex-secret` | `argo-cd` | (all paths) | GitHub OAuth credentials + every Dex static client secret |
+| `argocd-monitor-oauth` | `argocd-monitor` | `monitor` | oauth2-proxy client + fresh cookie secret |
+| `grafana-oauth-secret` | `monitoring` | `grafana` | Grafana Dex client secret |
+| `open-webui-oauth-secret` | `open-webui` | `open-webui` | Open WebUI Dex client secret |
+| `alertmanager-slack-secret` | `monitoring` | `slack` | Slack incoming webhook URL |
+
+### Bootstrap mode (seal everything)
+
+Use this on initial setup or after a cluster rebuild:
+
+```bash
+GITHUB_CLIENT_ID=Iv1.xxx \
+GITHUB_CLIENT_SECRET=xxx \
+SLACK_WEBHOOK_URL=https://hooks.slack.com/services/... \
+  scripts/seal-argocd-dex
+```
+
+Equivalent to `scripts/seal-argocd-dex all`. Any variable you omit is
+prompted for interactively. Leave `SLACK_WEBHOOK_URL` blank at the
+prompt to skip sealing the Alertmanager Slack secret.
+
+### Rotate a single secret
+
+The subcommands re-seal one logical secret without re-prompting for
+unrelated values. They read existing keys from the running
+`argocd-dex-secret` to preserve everything they don't touch, so you
+must have run `all` once before.
+
+```bash
+scripts/seal-argocd-dex github       # Update GitHub OAuth credentials
+scripts/seal-argocd-dex argocd       # Re-derive argo-cd client from server.secretkey
+scripts/seal-argocd-dex monitor      # Rotate argocd-monitor client + cookie
+scripts/seal-argocd-dex grafana      # Rotate grafana Dex client secret
+scripts/seal-argocd-dex open-webui   # Rotate open-webui Dex client secret
+scripts/seal-argocd-dex slack        # Re-seal alertmanager Slack webhook
+```
+
+The `slack` subcommand stands alone (its secret is not part of
+`argocd-dex-secret`). Pass `SLACK_WEBHOOK_URL=...` or it prompts
+interactively — blank input is an error in this mode (use `all` to
+skip).
+
+### After running
+
+Commit the updated `*-secret.yaml` files and push. ArgoCD syncs them
+and the sealed-secrets controller decrypts them. Pods that read
+secrets via `envFrom` or `secretKeyRef` (Dex, Grafana, Open WebUI,
+Headlamp, argocd-monitor) cache values at startup, so the script also
+rolls out the affected workloads automatically.
 
 ## Rotate a secret
 

--- a/docs/how-to/monitoring.md
+++ b/docs/how-to/monitoring.md
@@ -62,15 +62,58 @@ prometheus:
 
 ## Alerting
 
-Alertmanager is deployed as part of the stack. By default, alerts are only visible
-in the Alertmanager UI (accessible via port-forward):
+Alertmanager is deployed as part of the stack and exposed at
+**https://alertmanager.your-domain.com** behind the shared oauth2-proxy
+(GitHub OAuth, admin emails only). The kube-prometheus-stack ships with a
+suite of default alert rules covering node health, pod restarts, PVC usage,
+certificate expiry, etc.
+
+### Configure Slack notifications
+
+Alertmanager is pre-configured to route all alerts to a `#alerts` Slack
+channel via a webhook URL stored in the `alertmanager-slack-secret`
+SealedSecret.
+
+To populate the webhook:
+
+1. **Create a Slack incoming webhook** at https://api.slack.com/apps:
+   - Create New App → From scratch
+   - Incoming Webhooks → toggle on → Add New Webhook to Workspace
+   - Pick the `#alerts` channel and copy the webhook URL
+
+2. **Seal it into the cluster**:
+
+   ```bash
+   kubectl create secret generic alertmanager-slack-secret \
+     --namespace monitoring \
+     --from-literal=webhook-url="https://hooks.slack.com/services/..." \
+     --dry-run=client -o yaml | \
+     kubeseal --controller-name sealed-secrets --controller-namespace kube-system --format yaml \
+     > kubernetes-services/additions/grafana/alertmanager-slack-secret.yaml
+   ```
+
+3. **Commit and push** — ArgoCD syncs the SealedSecret, the controller
+   decrypts it, and the Prometheus operator rolls the Alertmanager pod
+   automatically with the webhook mounted.
+
+### Test the Slack integration
+
+Post a fake alert directly to the Alertmanager API:
 
 ```bash
-kubectl -n monitoring port-forward svc/alertmanager-operated 9093
-# Open http://localhost:9093
+kubectl exec -n monitoring \
+  alertmanager-grafana-prometheus-kube-pr-alertmanager-0 \
+  -c alertmanager -- \
+  wget -qO- --post-data='[{"labels":{"alertname":"SlackTestAlert","severity":"warning"},"annotations":{"summary":"Test alert"}}]' \
+  --header='Content-Type: application/json' \
+  http://localhost:9093/api/v2/alerts
 ```
 
-To configure alert notifications (email, Slack, PagerDuty), add an Alertmanager
-config to the Helm values. See the
-[kube-prometheus-stack documentation](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
-for details.
+A message should appear in `#alerts` within 30 seconds (the configured
+`group_wait`). If nothing arrives, check the alertmanager logs:
+
+```bash
+kubectl logs -n monitoring \
+  alertmanager-grafana-prometheus-kube-pr-alertmanager-0 \
+  -c alertmanager --tail=30
+```


### PR DESCRIPTION
## Summary
- Document the new Alertmanager + Slack setup in `docs/how-to/monitoring.md` (sealing the webhook, testing via the API)
- Document `seal-argocd-dex` bootstrap mode and per-secret subcommands in `docs/how-to/manage-sealed-secrets.md`
- Add CLAUDE.md foot-guns: SealedSecret placeholders must use valid base64; the seal script has subcommands for targeted rotation

## Test plan
- [x] No code changes — docs and CLAUDE.md only

🤖 Generated with [Claude Code](https://claude.com/claude-code)