### PR TITLE
Plumb alertmanager-slack-secret through rebuild scripts

### DIFF
--- a/scripts/export-external-creds
+++ b/scripts/export-external-creds
@@ -1,8 +1,10 @@
 #!/bin/bash
-# Export the 8 external credentials (GitHub OAuth, Cloudflare) from the
+# Export external credentials (GitHub OAuth, Cloudflare, Slack) from the
 # running cluster into a .env file at the repo root (gitignored).
 set -euo pipefail
 get_key() { kubectl get secret "$1" -n "$2" -o jsonpath="{.data.$3}" | base64 -d; }
+# Optional secret: returns empty if the secret/key doesn't exist.
+get_key_opt() { kubectl get secret "$1" -n "$2" -o jsonpath="{.data.$3}" 2>/dev/null | base64 -d 2>/dev/null || true; }
 cat > .env <<EOF
 GITHUB_CLIENT_ID=$(get_key argocd-dex-secret argo-cd 'dex\.github\.clientID')
 GITHUB_CLIENT_SECRET=$(get_key argocd-dex-secret argo-cd 'dex\.github\.clientSecret')
@@ -12,6 +14,7 @@ OAUTH2_PROXY_CLIENT_ID=$(get_key oauth2-proxy-credentials oauth2-proxy client-id
 OAUTH2_PROXY_CLIENT_SECRET=$(get_key oauth2-proxy-credentials oauth2-proxy client-secret)
 OPEN_BRAIN_GITHUB_CLIENT_ID=$(get_key open-brain-mcp-secret open-brain-mcp GITHUB_CLIENT_ID)
 OPEN_BRAIN_GITHUB_CLIENT_SECRET=$(get_key open-brain-mcp-secret open-brain-mcp GITHUB_CLIENT_SECRET)
+SLACK_WEBHOOK_URL=$(get_key_opt alertmanager-slack-secret monitoring webhook-url)
 EOF
-echo "Wrote .env (8 credentials, gitignored)"
+echo "Wrote .env (gitignored)"
 echo "Source with: set -a && source .env && set +a"

--- a/scripts/extract-secrets
+++ b/scripts/extract-secrets
@@ -27,6 +27,7 @@ SECRETS = [
     ("argocd-monitor", "argocd-monitor-oauth"),
     ("cert-manager", "cloudflare-api-token"),
     ("cloudflared", "cloudflared-credentials"),
+    ("monitoring", "alertmanager-slack-secret"),
     ("monitoring", "grafana-oauth-secret"),
     ("oauth2-proxy", "oauth2-proxy-credentials"),
     ("open-brain-mcp", "open-brain-mcp-secret"),

--- a/scripts/generate-secrets
+++ b/scripts/generate-secrets
@@ -23,6 +23,7 @@ Required env vars:
 
 Optional env vars:
     ADMIN_PASSWORD     — shared admin password (generated if not set)
+    SLACK_WEBHOOK_URL  — Alertmanager Slack notification webhook (empty if not set)
     SMTP_USERNAME      — Supabase SMTP (empty if not set)
     SMTP_PASSWORD      — Supabase SMTP (empty if not set)
     OPENAI_API_KEY     — Supabase OpenAI (empty if not set)
@@ -250,6 +251,17 @@ def main() -> None:
             "client-secret": openwebui_secret,
         },
     })
+
+    # 4b. alertmanager-slack-secret (optional — only included if URL provided)
+    slack_webhook_url = opt_env("SLACK_WEBHOOK_URL")
+    if slack_webhook_url:
+        extracted.append({
+            "namespace": "monitoring",
+            "name": "alertmanager-slack-secret",
+            "data": {
+                "webhook-url": slack_webhook_url,
+            },
+        })
 
     # 5. cloudflare-api-token
     extracted.append({

--- a/scripts/seal-from-json
+++ b/scripts/seal-from-json
@@ -98,5 +98,15 @@ kubectl create secret generic supabase-mcp-env --namespace=supabase \
     --from-literal=MCP_ACCESS_KEY="$mcp_key" \
     --dry-run=client -o yaml | seal_to "$BASE/supabase/templates/mcp-env-secret.yaml"
 echo "  -> $BASE/supabase/templates/mcp-env-secret.yaml"
+# 7. alertmanager-slack-secret (monitoring) — optional, only if present in JSON
+if has_secret alertmanager-slack-secret monitoring; then
+    echo "Sealing: alertmanager-slack-secret..."
+    kubectl create secret generic alertmanager-slack-secret --namespace=monitoring \
+        --from-literal=webhook-url="$(get_key alertmanager-slack-secret monitoring webhook-url)" \
+        --dry-run=client -o yaml | seal_to "$BASE/grafana/alertmanager-slack-secret.yaml"
+    echo "  -> $BASE/grafana/alertmanager-slack-secret.yaml"
+else
+    echo "Skipping: alertmanager-slack-secret (not in JSON)"
+fi
 echo ""
 echo "All non-Dex secrets sealed. Run 'just seal-argocd-dex' separately for Dex/OAuth secrets."


### PR DESCRIPTION
## Summary
The Slack webhook secret was added to \`seal-argocd-dex\` (#303/#305) but the surrounding rebuild/extract/generate flow didn't know about it, so a cluster rebuild would silently lose the secret. This PR plumbs it through:

- **\`export-external-creds\`** — emit \`SLACK_WEBHOOK_URL\` (optional — empty if not yet sealed)
- **\`extract-secrets\`** — include \`alertmanager-slack-secret\` in the extraction list
- **\`generate-secrets\`** — read \`SLACK_WEBHOOK_URL\` as an optional env var and include the secret in the JSON output when set
- **\`seal-from-json\`** — seal \`alertmanager-slack-secret\` if present in the JSON

## Test plan
- [x] \`scripts/export-external-creds\` against the live cluster writes \`SLACK_WEBHOOK_URL\` into \`.env\`
- [ ] Full rebuild round-trip: extract → tear down → rebuild → seal-from-json → confirm Alertmanager Slack notifications still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)