### PR TITLE
Fix Prometheus scrape alerts: TLS SANs + K3s component disables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,20 @@
   an override without editing `group_vars/all.yml`. Never change
   `repo_branch` in `all.yml` — it must always be `main`. To revert,
   run `just switch-branch main`.
+- **Check what the cluster is actually tracking before branching** — the
+  cluster may be on a feature branch (e.g. mid-validation of an open PR),
+  not `main`. Branching new work off `origin/main` then running
+  `just switch-branch <new-branch>` will silently roll back any commits
+  that exist only on the previously-tracked branch. The most painful
+  case is sealed secrets re-sealed during a rebuild: the new branch
+  applies the older (un-decryptable) versions from `main`, the
+  controller logs `no key could decrypt secret`, and consumer pods
+  drift from their live Secrets. Before creating a new working branch,
+  run `kubectl -n argo-cd get application <app> -o jsonpath='{.spec.sources[*].targetRevision}'`
+  (or any ArgoCD app pointing at this repo) to see the actual tracked
+  branch. If it's not `main`, **stop and ask the user** whether to:
+  (a) merge the tracked branch to main first, then branch off main, or
+  (b) base the new work on the currently-tracked branch.
 - **`known_hosts` task must be `serial: 1`** — parallel writes race.
 - **Traefik is disabled** — project uses `--disable=traefik` with NGINX Ingress.
 - **Multi-homed nodes** — K3s and flannel auto-detect the IP from the default

--- a/kubernetes-services/templates/grafana.yaml
+++ b/kubernetes-services/templates/grafana.yaml
@@ -178,6 +178,24 @@ spec:
                 value: "true"
                 effect: NoSchedule
 
+          # K3s bundles scheduler, controller-manager and kube-proxy into the
+          # k3s-server process — there are no pods with component=kube-scheduler
+          # etc., so the chart-default Services end up with empty endpoints and
+          # the matching Down alert rules fire via absent(up{...}). Disable both
+          # the scrape targets and the default rules. The same components are
+          # still visible via the apiserver and kubelet ServiceMonitors.
+          kubeControllerManager:
+            enabled: false
+          kubeScheduler:
+            enabled: false
+          kubeProxy:
+            enabled: false
+          defaultRules:
+            rules:
+              kubeControllerManager: false
+              kubeScheduler: false
+              kubeProxyAlerting: false
+
     - path: ./kubernetes-services/additions/grafana
       repoURL: {{ .Values.repo_remote }}
       targetRevision: {{ .Values.repo_branch }}

--- a/roles/cluster/tasks/main.yml
+++ b/roles/cluster/tasks/main.yml
@@ -59,23 +59,10 @@
 
 # kube-prometheus-stack's webhook TLS secret is normally created by a Helm
 # hook job, but ArgoCD prunes hook jobs so the secret never appears.
-# Create a self-signed cert and apply idempotently. (#6 rebuild checklist)
+# Delegate to the script to keep cert generation (including the SAN list
+# required by the operator ServiceMonitor) in one place. (#6 rebuild checklist)
 - name: Create Prometheus admission webhook TLS secret
-  ansible.builtin.shell:
-    cmd: |
-      set -euo pipefail
-      TMPDIR=$(mktemp -d)
-      trap 'rm -rf "$TMPDIR"' EXIT
-      openssl req -x509 -newkey rsa:2048 \
-          -keyout "$TMPDIR/key.pem" -out "$TMPDIR/cert.pem" \
-          -days 365 -nodes \
-          -subj '/CN=grafana-prometheus-kube-pr-admission.monitoring.svc' 2>/dev/null
-      kubectl create namespace monitoring --dry-run=client -o yaml | kubectl apply -f -
-      kubectl create secret generic grafana-prometheus-kube-pr-admission \
-          -n monitoring \
-          --from-file=cert="$TMPDIR/cert.pem" \
-          --from-file=key="$TMPDIR/key.pem" \
-          --from-file=ca="$TMPDIR/cert.pem" \
-          --dry-run=client -o yaml | kubectl apply -f -
-    executable: /bin/bash
+  ansible.builtin.command:
+    cmd: scripts/create-prometheus-admission-secret
+    chdir: "{{ playbook_dir }}"
   changed_when: true

--- a/scripts/create-prometheus-admission-secret
+++ b/scripts/create-prometheus-admission-secret
@@ -4,10 +4,17 @@
 set -euo pipefail
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
+# The operator serves its metrics endpoint with this cert too (not just the
+# admission webhook), so the SAN list must cover both Service names. Modern
+# TLS verification ignores CN and requires a SAN match; a single-CN cert
+# makes the kube-pr-operator ServiceMonitor's TLS verify fail and fires
+# TargetDown.
 openssl req -x509 -newkey rsa:2048 \
     -keyout "$TMPDIR/key.pem" -out "$TMPDIR/cert.pem" \
     -days 365 -nodes \
-    -subj '/CN=grafana-prometheus-kube-pr-admission.monitoring.svc' 2>/dev/null
+    -subj '/CN=grafana-prometheus-kube-pr-admission.monitoring.svc' \
+    -addext 'subjectAltName=DNS:grafana-prometheus-kube-pr-admission,DNS:grafana-prometheus-kube-pr-admission.monitoring.svc,DNS:grafana-prometheus-kube-pr-admission.monitoring.svc.cluster.local,DNS:grafana-prometheus-kube-pr-operator,DNS:grafana-prometheus-kube-pr-operator.monitoring.svc,DNS:grafana-prometheus-kube-pr-operator.monitoring.svc.cluster.local' \
+    2>/dev/null
 kubectl create namespace monitoring --dry-run=client -o yaml | kubectl apply -f -
 kubectl create secret generic grafana-prometheus-kube-pr-admission \
     -n monitoring \


### PR DESCRIPTION
## Summary

Clears four firing alerts (`TargetDown`, `KubeSchedulerDown`, `KubeProxyDown`, `KubeControllerManagerDown`) caused by two unrelated scrape-config problems.

### 1. Operator `TargetDown`

The kube-prometheus-stack operator serves its metrics endpoint with the cert from `grafana-prometheus-kube-pr-admission`. Our `scripts/create-prometheus-admission-secret` minted a single-CN cert with **no** SAN list, so modern TLS verification (SAN-only, CN ignored) made the operator ServiceMonitor's `serverName: grafana-prometheus-kube-pr-operator` verify fail every scrape.

Add a `subjectAltName` list covering both Service names in three forms each:
- bare (`grafana-prometheus-kube-pr-operator`) — matches the ServiceMonitor's literal `serverName`
- `.monitoring.svc`
- `.monitoring.svc.cluster.local`

### 2. `Kube{Scheduler,Proxy,ControllerManager}Down`

K3s runs scheduler, controller-manager and kube-proxy inside the single `k3s-server` process. No pods are labelled `component: kube-scheduler` etc., so the chart-default Services in `kube-system` end up with empty endpoints, `up{job=...}` is absent, and the matching Down rules fire.

Disable the three exporters and the three `defaultRules` entries. The same components remain visible via the apiserver and kubelet ServiceMonitors that are already scraping cleanly.

## Validation

Cert fix was applied live on the cluster (re-ran the script, cycled the operator and Prometheus pods). After cycling:

```
down/unknown: 0
```

All scrape targets report healthy. The grafana template change still needs to flow through ArgoCD — tested by switching the cluster branch to this PR before merging.

## Test plan

- [x] Cert generator produces a six-SAN cert (validated with `openssl x509 -ext subjectAltName`)
- [x] Operator pod serves the new cert and Prometheus verifies it successfully
- [x] All active scrape targets report `up`
- [ ] `just switch-branch fix/prometheus-scrape-alerts` on the cluster
- [ ] ArgoCD syncs `grafana-prometheus` Application cleanly
- [ ] Three `Kube*Down` rules disappear from `kubectl get prometheusrule -n monitoring`
- [ ] `TargetDown` / `Kube*Down` alerts clear in Alertmanager