### PR TITLE
Document rebuild-test workflow in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,28 @@
   clusters. Write all docs for a general audience. Specific node names
   (ws03, nuc2, node01) are fine as labelled examples.
 
+## Testing Rebuild-Affecting Changes
+
+Changes to Ansible roles, secret derivation, CoreDNS, or ArgoCD app
+templates can silently break the rebuild path while the live cluster
+stays healthy. Validate with a full rebuild **before** merging:
+
+1. Push your change to a feature branch and `just switch-branch <branch>`
+   to point the live cluster at it.
+2. Open a PR (draft is fine).
+3. `/rebuild-cluster on this branch to test #<PR>` — the skill branches
+   off your PR, decommissions, and rebuilds against that branch.
+4. If the rebuild surfaces bugs, fix them and cherry-pick the fix
+   commit(s) onto the PR branch (force-push).
+5. **Cherry-pick the playbook-generated `Re-seal all secrets for
+   rebuilt cluster` commit onto the PR branch as a separate commit.**
+   One merge must deliver both the code fix *and* the new sealed
+   secrets — otherwise `main` keeps the old (un-decryptable)
+   ciphertexts and the cluster can't be safely pointed back at `main`
+   after merge.
+6. Merge the PR, then `ansible-playbook pb_all.yml --tags cluster` to
+   switch ArgoCD tracking back to `main`. Delete the rebuild branch.
+
 ## Key Paths
 
 - Playbook: `pb_all.yml` (not `site.yml`); decommission: `pb_decommission.yml`


### PR DESCRIPTION
## Summary

- Add a new \`## Testing Rebuild-Affecting Changes\` section to CLAUDE.md capturing the rebuild-test workflow we used to validate gilesknap/tpi-k3s-ansible#311.
- The non-obvious step is #5: cherry-pick the playbook-generated \`Re-seal all secrets for rebuilt cluster\` commit onto the PR branch as a separate commit, so the code fix and the new sealed ciphertexts land on \`main\` in a single merge. Without it, the cluster can't be safely pointed back at \`main\` after merge.
- Captures the pattern derived from the #311 + #314 work: #311 carried the code fix, #314 carried the reseal — merging both before switching cluster tracking worked, but doing it as a single PR with two commits is cleaner going forward.

## Test plan

- [ ] Read the new section; confirm it's accurate and non-redundant with the \`/rebuild-cluster\` skill
- [ ] On the next rebuild-affecting change, follow the documented workflow end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)