### PR TITLE
Migrate invocation-only skills to commands

### DIFF
--- a/.claude/commands/add-node.md
+++ b/.claude/commands/add-node.md
@@ -1,9 +1,3 @@
----
-name: add-node
-description: Interactively add a new worker node to an existing K3s cluster — configure inventory, bootstrap SSH, join cluster, and adjust topology settings.
-user_invocable: true
----
-
 # Add Node
 
 Guide the user through adding a new worker node to an existing cluster. Ask

--- a/.claude/commands/bootstrap-cluster.md
+++ b/.claude/commands/bootstrap-cluster.md
@@ -1,9 +1,3 @@
----
-name: bootstrap-cluster
-description: Interactively bootstrap a K3s cluster from scratch — configure inventory, generate secrets, run playbooks, and produce a credentials file.
-user_invocable: true
----
-
 # Bootstrap Cluster
 
 Guide the user through setting up a K3s cluster from scratch. Ask questions

--- a/.claude/commands/memo.md
+++ b/.claude/commands/memo.md
@@ -1,8 +1,3 @@
----
-name: memo
-description: Save current task state to auto-memory, then promote reusable knowledge to docs/skills/CLAUDE.md and trim memory.
----
-
 # Memo
 
 Save a snapshot of current work to persistent memory, then graduate

--- a/.claude/commands/pr-squash.md
+++ b/.claude/commands/pr-squash.md
@@ -1,8 +1,3 @@
----
-name: pr-squash
-description: Squash-merge the current branch's commits into logical groups (by feature/fix) on a new branch and create a PR. Use when the user wants to clean up commit history before merging, especially after iterative CI/CD work.
----
-
 # PR Squash
 
 Create a clean PR by grouping the current branch's commits into logical squashed

--- a/.claude/commands/rebuild-cluster.md
+++ b/.claude/commands/rebuild-cluster.md
@@ -1,9 +1,3 @@
----
-name: rebuild-cluster
-description: Tear down and rebuild the K3s cluster from scratch to validate documentation and commissioning. Destructive — all Longhorn data is lost.
-user-invocable: true
----
-
 # Rebuild Cluster
 
 Decommission and rebuild the K3s cluster from scratch, validating the
@@ -12,7 +6,7 @@ Supabase DB backups) survives; **Longhorn PVC data is destroyed**.
 
 ## WARNING — DATA LOSS
 
-This skill **destroys all Longhorn-backed persistent data** including:
+This command **destroys all Longhorn-backed persistent data** including:
 - Prometheus/Grafana metrics history
 - Open WebUI chat history and uploads
 - Supabase database (tables, storage objects, edge functions)
@@ -47,6 +41,20 @@ git push -u origin rebuild-$(date +%Y%m%d)
 **Push the branch immediately** — ArgoCD's root app is configured with
 `repo_branch` during Phase 3 and will fail to sync if the branch does
 not exist on the remote (`unable to resolve '<branch>' to a commit SHA`).
+
+#### If testing a PR branch
+
+A common invocation is "rebuild on this branch to test PR #N". The PR
+branch itself is the base branch for the rebuild:
+
+1. Ask the user to `just switch-branch <pr-branch>` first so the live
+   cluster is pointing at the PR state. (They should have a draft PR
+   open already.)
+2. Use the PR branch as `<base-branch>` in the commands above.
+3. Note that this is a PR-testing rebuild — **Phase 8 has extra steps**
+   (cherry-picking fixes and the reseal commit back onto the PR branch)
+   so that merging the PR delivers both the code fix and the new sealed
+   secrets in one go.
 
 ### 1b. Collect external credentials
 
@@ -247,7 +255,7 @@ All services must respond (no timeouts or 5xx errors).
 
 ## Phase 7: Verify via browser
 
-Invoke **`/test-oauth-flow`** — that skill contains the full browser
+Invoke **`/test-oauth-flow`** — that command contains the full browser
 test matrix, cookie-clearing JavaScript, scroll-jacking workaround,
 and failure-reporting procedure, and delegates the browser work to a
 subagent to keep the main conversation context clean.
@@ -290,13 +298,38 @@ after they have tested the cluster manually.
 rm -rf /tmp/cluster-secrets/
 ```
 
-### 8e. Report
+### 8e. If this rebuild was testing a PR branch
+
+Skip this subsection for fresh rebuilds. For PR-testing rebuilds, the
+user wants one merge of **their PR** to deliver both the code fix *and*
+the new sealed secrets — otherwise `main` keeps the old un-decryptable
+ciphertexts and the cluster can't be safely pointed back at `main`
+after merge.
+
+1. **Cherry-pick any fix commits** made on the rebuild branch (bugs
+   surfaced during rebuild) back onto the PR branch, then force-push
+   the PR branch.
+2. **Cherry-pick the playbook-generated `Re-seal all secrets for
+   rebuilt cluster` commit** from the rebuild branch onto the PR
+   branch as a separate commit. Force-push the PR branch.
+3. **Do not** create a second PR from the rebuild branch — the PR
+   that gets merged is the user's original PR, now carrying the
+   reseal commit.
+4. After the user merges their PR, they run
+   `ansible-playbook pb_all.yml --tags cluster` (no `--extra-vars`)
+   to switch ArgoCD tracking back to `main`, then delete the rebuild
+   branch.
+
+### 8f. Report
 
 Tell the user:
 - The cluster is rebuilt and all services are verified
 - ArgoCD is tracking the **rebuild branch** (not main)
-- The PR is ready for review
-- After merging the PR, run this command to switch ArgoCD back to main:
+- For fresh rebuilds: the PR is ready for review
+- For PR-testing rebuilds: any fix commits and the reseal commit have
+  been cherry-picked onto their PR branch and force-pushed; their PR
+  is ready to merge
+- After merging, run this command to switch ArgoCD back to main:
   ```
   SSH_AUTH_SOCK="/tmp/ssh-agent.sock" ansible-playbook pb_all.yml --tags cluster
   ```

--- a/.claude/commands/test-oauth-flow.md
+++ b/.claude/commands/test-oauth-flow.md
@@ -1,23 +1,9 @@
----
-name: test-oauth-flow
-description: Browser-test all cluster services for OAuth/auth flow verification. Delegates to a subagent to protect main context.
-user-invocable: true
----
-
 # Test OAuth Flow
 
 Verify that every cluster service is reachable and authentication works
-end-to-end using Chrome browser automation. This skill delegates all
+end-to-end using Chrome browser automation. This command delegates all
 browser work to a subagent to protect the main conversation context from
 screenshot and redirect bloat.
-
-## How to invoke
-
-```
-/test-oauth-flow
-```
-
-No arguments needed. Reads `cluster_domain` from `group_vars/all.yml`.
 
 ## Important rules
 

--- a/.claude/skills/ansible/SKILL.md
+++ b/.claude/skills/ansible/SKILL.md
@@ -29,9 +29,9 @@ description: Ansible playbook structure, tags, topology rules, branch switching,
 - **All ansible commands need `SSH_AUTH_SOCK="/tmp/ssh-agent.sock"`**
   (start with `just ssh-agent`).
 - **Commits need `uv run`** — pre-commit hooks live in the uv venv.
-- **Adding a node**: use `/add-node` skill.
-- **Full bootstrap**: use `/bootstrap-cluster` skill.
-- **Rebuild cluster**: use `/rebuild-cluster` skill.
+- **Adding a node**: run `/add-node`.
+- **Full bootstrap**: run `/bootstrap-cluster`.
+- **Rebuild cluster**: run `/rebuild-cluster`.
 
 ## Branch switching
 
@@ -94,7 +94,7 @@ reboot unexpectedly. This has three consequences you must design for:
 Replica counts in `kubernetes-services/values.yaml` must match the
 number of Longhorn-capable nodes (i.e. excluding ws03). Going too high
 leaves volumes permanently Degraded; going too low under-replicates on
-adds. Update after any `add-node` run.
+adds. Update after any `/add-node` run.
 
 ## Foot-guns
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,6 @@
 - **Rebase over `main` before new work** — squash-merged commits have
   different SHAs from the originals, so skipping rebase causes phantom
   conflicts.
-- **Use `uv run`** for git commits (pre-commit hooks need the uv venv).
 - **Chrome browser is not incognito** — never navigate to Google services.
   For GitHub: OAuth "Grant Access" / "Authorize" clicks are OK (they only
   redirect back to the cluster), but do not modify any GitHub resources
@@ -27,23 +26,9 @@
 
 Changes to Ansible roles, secret derivation, CoreDNS, or ArgoCD app
 templates can silently break the rebuild path while the live cluster
-stays healthy. Validate with a full rebuild **before** merging:
-
-1. Push your change to a feature branch and `just switch-branch <branch>`
-   to point the live cluster at it.
-2. Open a PR (draft is fine).
-3. `/rebuild-cluster on this branch to test #<PR>` — the skill branches
-   off your PR, decommissions, and rebuilds against that branch.
-4. If the rebuild surfaces bugs, fix them and cherry-pick the fix
-   commit(s) onto the PR branch (force-push).
-5. **Cherry-pick the playbook-generated `Re-seal all secrets for
-   rebuilt cluster` commit onto the PR branch as a separate commit.**
-   One merge must deliver both the code fix *and* the new sealed
-   secrets — otherwise `main` keeps the old (un-decryptable)
-   ciphertexts and the cluster can't be safely pointed back at `main`
-   after merge.
-6. Merge the PR, then `ansible-playbook pb_all.yml --tags cluster` to
-   switch ArgoCD tracking back to `main`. Delete the rebuild branch.
+stays healthy. Before merging such a PR, suggest validating it with
+`/rebuild-cluster` on the PR branch — the command handles the PR-test
+workflow, including cherry-picking the reseal commit back.
 
 ## Key Paths
 

--- a/docs/tutorials/ai-guided-setup.md
+++ b/docs/tutorials/ai-guided-setup.md
@@ -1,7 +1,7 @@
 # AI-Guided Setup
 
 The fastest way to get a cluster running is to let Claude Code walk you through
-it interactively. The `/bootstrap-cluster` skill asks you a series of questions,
+it interactively. The `/bootstrap-cluster` command asks you a series of questions,
 configures all the files, generates secrets, runs the Ansible playbooks, and
 writes a credentials file — all in one conversation.
 
@@ -25,7 +25,7 @@ Then open the devcontainer:
 :end-before: <!-- end:devcontainer -->
 ```
 
-## Run the skill
+## Run the command
 
 Open a Claude Code session inside the devcontainer and type:
 
@@ -55,8 +55,8 @@ network speed.
 
 ## What happens next
 
-After the skill completes, your cluster is running with all core services
-managed by ArgoCD. The skill will print next steps, but here is a summary:
+After the command completes, your cluster is running with all core services
+managed by ArgoCD. Claude will print next steps, but here is a summary:
 
 - **Access services now** via port-forward — see {doc}`/how-to/accessing-services`
 - **Expose services to the internet** — follow {doc}`/how-to/cloudflare-tunnel`


### PR DESCRIPTION
## Summary
- Six skills that only made sense when explicitly invoked (`add-node`, `bootstrap-cluster`, `rebuild-cluster`, `test-oauth-flow`, `pr-squash`, `memo`) move from `.claude/skills/` to `.claude/commands/`. Reference-material skills (`ansible`, `cloudflare`, `oauth`, `sealed-secrets`) stay put.
- `/rebuild-cluster` gains a "If testing a PR branch" subsection in Phase 1a and a new Phase 8e covering the cherry-pick-the-reseal-commit dance — previously this procedure lived only in CLAUDE.md and was missing from the command itself, a latent gap that could have let stale sealed secrets land on main after a PR-test rebuild.
- `CLAUDE.md`'s "Testing Rebuild-Affecting Changes" section shrinks from 21 lines to 6: retains the trigger (which changes warrant a rebuild test) so the nudge stays in always-loaded context, defers the procedure to the command.

## Motivation
The invocation-only skills had their full descriptions sitting in every turn's skill list — ~150 words of context that only mattered when the command was explicitly typed. Converting to commands cuts that to the H1 heading (~12 words total across all six) and is the semantically correct home for interactive procedures.

Four of the six were already self-flagged with `user_invocable: true` in their frontmatter, which was the original signal that they didn't belong in ambient context.

## Test plan
- [ ] `/bootstrap-cluster`, `/rebuild-cluster`, `/add-node`, `/test-oauth-flow`, `/pr-squash`, `/memo` all still tab-complete and invoke
- [ ] Remaining skills (`/ansible`, `/cloudflare`, `/oauth`, `/sealed-secrets`) still load with full descriptions
- [ ] Pre-commit hooks pass (they did locally)
- [ ] No stale "skill" wording in docs — verified via grep before push

🤖 Generated with [Claude Code](https://claude.com/claude-code)