### PR TITLE
Scaffold drop-Longhorn infrastructure (PR 1 of 2, no cutover)

### DIFF
--- a/docs/explanations/ansible-roles.md
+++ b/docs/explanations/ansible-roles.md
@@ -1,6 +1,6 @@
 # Ansible Roles in Detail
 
-The playbook `pb_all.yml` runs seven roles in sequence. Each role is fully idempotent —
+The playbook `pb_all.yml` runs eight roles in sequence. Each role is fully idempotent —
 it checks state before acting and does nothing if the desired state is already achieved.
 
 ## Execution order
@@ -12,7 +12,8 @@ flowchart TD
     F --> KH["known_hosts<br/><i>all_nodes + turing_pis</i>"]
     KH --> MF["move_fs<br/><i>all_nodes</i>"]
     MF --> UP["update_packages<br/><i>all_nodes</i>"]
-    UP --> K["k3s<br/><i>all_nodes</i>"]
+    UP --> DD["k8s_data_dirs<br/><i>all_nodes</i>"]
+    DD --> K["k3s<br/><i>all_nodes</i>"]
     K --> C["cluster<br/><i>localhost</i>"]
 ```
 
@@ -24,7 +25,7 @@ ansible-playbook pb_all.yml --tags flash
 # etc.
 ```
 
-The `servers` tag covers both `move_fs` and `update_packages`.
+The `servers` tag covers `move_fs`, `update_packages`, and `k8s_data_dirs`.
 
 ---
 
@@ -160,6 +161,33 @@ Prepares each node for K3s:
      runtime set as the default containerd runtime. k3s regenerates `config.toml` on
      every agent restart from this template, so the configuration persists across reboots.
    - Restart `k3s-agent` to apply the new containerd config
+
+---
+
+## `k8s_data_dirs` — Local PV host directories
+
+**Runs on:** `all_nodes`
+**Tag:** `servers`
+
+Creates the host directories that back the `local-nvme` PVs defined in
+`kubernetes-services/additions/local-storage/`. Each app's PV is pinned via
+`nodeAffinity` to one specific node, so the role creates each directory only
+on its target node (guarded by `inventory_hostname`).
+
+| Node   | Directory                         | Owner / mode         | Consumed by |
+|--------|-----------------------------------|----------------------|-------------|
+| nuc2   | `/home/k8s-data/supabase-db`      | root / 0777          | supabase    |
+| nuc2   | `/home/k8s-data/supabase-storage` | root / 0777          | supabase    |
+| nuc2   | `/home/k8s-data/supabase-minio`   | 65532:65532 / 0755   | supabase    |
+| node02 | `/var/lib/k8s-data/prometheus`    | 1000:2000 / 0755     | monitoring  |
+| node03 | `/var/lib/k8s-data/grafana`       | 472:472 / 0755       | monitoring  |
+| node04 | `/var/lib/k8s-data/open-webui`    | root / 0777          | open-webui  |
+
+Data lives outside `/var/lib/rancher` deliberately: `pb_decommission.yml`
+wipes `/var/lib/rancher` to reset K3s, but these directories are preserved
+so PVC data survives a cluster rebuild. The one-time NFS share setup that
+hosts the backup CronJob output is a separate manual runbook — see
+`docs/how-to/nas-setup.md`.
 
 ---
 

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -39,6 +39,7 @@ how-to/node-operations
 how-to/upgrade-k3s
 how-to/reflash-rebuild
 how-to/alternative-storage
+how-to/nas-setup
 ```
 
 ## Developer Workflow

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -13,6 +13,7 @@ how-to/cloudflare-tunnel
 how-to/cloudflare-ssh-tunnel
 how-to/cloudflare-web-tunnel
 how-to/oauth-setup
+how-to/nas-setup
 ```
 
 ## Optional Features
@@ -39,7 +40,6 @@ how-to/node-operations
 how-to/upgrade-k3s
 how-to/reflash-rebuild
 how-to/alternative-storage
-how-to/nas-setup
 ```
 
 ## Developer Workflow

--- a/docs/how-to/nas-setup.md
+++ b/docs/how-to/nas-setup.md
@@ -1,122 +1,171 @@
-# Set Up the Cluster NFS Share on the NAS
+# Set Up the Cluster NFS Tree on the NAS
 
-This is a **one-time manual runbook** you run by hand on the NAS. Ansible has
-no access to the NAS and this is by design: the NAS hosts unrelated personal
-data (JellyFin libraries, files, etc.) alongside the cluster's NFS shares,
-and we don't want an ansible playbook anywhere near it.
+This is a **one-time manual runbook** you run by hand on the NAS (a QNAP).
+Ansible has no access to the NAS and this is by design: the NAS hosts
+unrelated personal data (JellyFin libraries, Minecraft, Public) alongside
+the cluster's NFS shares, and we don't want an ansible playbook anywhere
+near it.
 
-The runbook creates `/bigdisk/k8s-cluster/` — a single new path that contains
-**everything** the cluster reads or writes over NFS:
+## Why this doesn't create a new NFS export
+
+On a stock Debian/Ubuntu NFS server, the clean pattern would be to add a
+drop-in file under `/etc/exports.d/` and reload exports. **QTS (the QNAP
+OS) does not work this way** — `/etc/exports` is auto-regenerated from the
+QNAP web UI's share configuration, there is no `/etc/exports.d/`, and
+hand-editing `/etc/exports` is dangerous because the UI overwrites it.
+
+The good news is we don't need a new export at all. Your QNAP already
+exports `/share/CACHEDEV1_DATA/bigdisk` with read-write access to the
+cluster subnet (`192.168.1.1/24`, which equals `192.168.1.0/24`). It is
+already mounted by rkllama, llamacpp, and the supabase db-dump PV using
+the client-visible NFSv4-pseudo-filesystem path `/bigdisk/...`.
+
+So this runbook **just creates a new subdirectory inside the existing
+`bigdisk` export** — `bigdisk/k8s-cluster/` — and populates it. No
+export changes, no `/etc/exports` edits, no QNAP UI configuration.
+
+## What we're creating
+
+A single directory tree `bigdisk/k8s-cluster/` that contains **everything**
+the cluster reads or writes over NFS:
 
 - `models/` — LLM model files consumed by rkllama and llamacpp
+  (populated from the existing `bigdisk/LMModels/` tree)
 - `supabase-dumps/` — Supabase database dumps
-- `backups/<app>/` — daily and weekly CronJob backup output
+  (populated from the existing `bigdisk/OpenBrain/` tree)
+- `backups/<app>/` and `backups/<app>/weekly/` — daily and weekly
+  CronJob backup output (empty on first setup)
 
-The runbook installs the NFS export as a drop-in (`/etc/exports.d/k8s-cluster.exports`)
-rather than editing `/etc/exports`. The kernel NFS server auto-merges
-everything under `/etc/exports.d/*.exports`, so existing shares are completely
-untouched and rollback is a one-liner.
+### Two paths, same directory
+
+Be aware of the two paths you'll see in this runbook — they are the same
+physical directory, just viewed from different sides:
+
+| Path                                        | Who uses it                         |
+|---------------------------------------------|-------------------------------------|
+| `/share/CACHEDEV1_DATA/bigdisk/k8s-cluster` | You, running commands on the QNAP   |
+| `/bigdisk/k8s-cluster`                      | The Kubernetes NFS PV (client-side) |
+
+The client-side path `/bigdisk/...` works because the QNAP exports a
+separate NFSv4-pseudo entry `/share/NFSv=4/bigdisk` with `nohide` and
+its own `fsid`, which makes `bigdisk` a first-class path for NFSv4
+clients. This is how rkllama and llamacpp already mount their models.
 
 ## Prerequisites
 
-- You can SSH to the NAS as root (or via `sudo -i`).
-- The NAS already runs `nfs-kernel-server` and serves at least one share
-  successfully. (It does if the current cluster's rkllama/llamacpp are working.)
-- `/bigdisk` exists on the NAS and has enough free space to duplicate the
-  existing `LMModels` tree (rsync of the whole models directory).
-- Cluster nodes are all on `192.168.1.0/24`.
+- You can SSH to the QNAP as `admin` (or another account with shell
+  access and rights to write under `/share/CACHEDEV1_DATA`).
+- The QNAP is reachable at `192.168.1.3` from the cluster subnet. Already
+  true — rkllama / llamacpp / supabase-db-data all currently mount from
+  there.
+- Enough free space on the volume to duplicate the existing `LMModels`
+  tree. Check with `du -sh /share/CACHEDEV1_DATA/bigdisk/LMModels` before
+  starting; compare against `df -h /share/CACHEDEV1_DATA`.
 
 ## Phase 1 — one-time setup + initial data copy
 
-Run this once on the NAS. It creates the directory tree, installs the
-export drop-in, reloads exports, and rsyncs the existing LLM models and
-Supabase DB dumps from their old paths into the new share.
-
-The old paths (`/bigdisk/LMModels` and `/bigdisk/OpenBrain`) are **preserved
-untouched** — they remain available as a rollback safety net. Do not delete
-them until you are certain the new setup is working in production.
+Run this once on the QNAP. It creates the directory tree and copies the
+existing LLM models and Supabase db dumps into their new homes. The old
+paths (`bigdisk/LMModels` and `bigdisk/OpenBrain`) are **preserved
+untouched** — they remain available as a rollback safety net. Do not
+delete them until you are certain the new setup is working.
 
 ```bash
-set -euo pipefail
+# SSH to the QNAP as admin, then:
 
-# 1. Create the cluster-owned directory tree. Owned by nobody:nogroup
-#    (UID/GID 65534) to match all_squash in the export.
-install -d -o 65534 -g 65534 -m 0755 /bigdisk/k8s-cluster
-install -d -o 65534 -g 65534 -m 0755 /bigdisk/k8s-cluster/models
-install -d -o 65534 -g 65534 -m 0755 /bigdisk/k8s-cluster/supabase-dumps
-install -d -o 65534 -g 65534 -m 0755 /bigdisk/k8s-cluster/backups
+set -eu
+
+# The real filesystem path of the existing /bigdisk export.
+# (Client-side, Kubernetes sees this as /bigdisk/k8s-cluster.)
+ROOT=/share/CACHEDEV1_DATA/bigdisk/k8s-cluster
+
+# 1. Create the cluster-owned directory tree.
+#    The export uses root_squash (root → 65534) but not all_squash, so
+#    writes from in-cluster pods arrive with their own UIDs. Leaf backup
+#    dirs use 0777 so mixed writers (alpine=root-squashed, postgres=999)
+#    can all write. Models/supabase-dumps are read-mostly so 0755 is fine.
+mkdir -p "$ROOT"
+mkdir -p "$ROOT/models"
+mkdir -p "$ROOT/supabase-dumps"
+mkdir -p "$ROOT/backups"
 for app in supabase-db supabase-storage supabase-minio grafana open-webui; do
-  install -d -o 65534 -g 65534 -m 0755 "/bigdisk/k8s-cluster/backups/${app}"
-  install -d -o 65534 -g 65534 -m 0755 "/bigdisk/k8s-cluster/backups/${app}/weekly"
+  mkdir -p "$ROOT/backups/$app"
+  mkdir -p "$ROOT/backups/$app/weekly"
 done
 
-# 2. Install the NFS export as a drop-in file. nfs-kernel-server auto-merges
-#    /etc/exports.d/*.exports with /etc/exports — we only write to the
-#    drop-in, so /etc/exports is never touched.
-cat > /etc/exports.d/k8s-cluster.exports <<'EOF'
-# Managed: written by docs/how-to/nas-setup.md from the k3s-ansible repo.
-# Rollback: rm /etc/exports.d/k8s-cluster.exports && exportfs -ra
-/bigdisk/k8s-cluster 192.168.1.0/24(rw,sync,no_subtree_check,root_squash,all_squash,anonuid=65534,anongid=65534,sec=sys)
-EOF
-chmod 0644 /etc/exports.d/k8s-cluster.exports
+chmod 0755 "$ROOT" "$ROOT/models" "$ROOT/supabase-dumps"
+chmod 0755 "$ROOT/backups"
+chmod -R 0777 "$ROOT/backups"/*
 
-# 3. Reload exports.
-exportfs -ra
-
-# 4. Initial data copy. Uses rsync -a (preserve perms/times) +
-#    --info=progress2 for a running total. The old paths remain untouched.
-#    These rsyncs are safe to run while the cluster is still using the old
-#    paths:
+# 2. Initial data copy — bulk-populate models/ and supabase-dumps/ from
+#    the existing paths. cp -a preserves perms/times. rsync is also
+#    available on QTS if you'd rather see progress:
+#      rsync -a --info=progress2 <src>/ <dst>/
+#
+#    Safe to run while the cluster is using the old paths:
 #    - LLM models are read-only in practice
-#    - Supabase dumps are written once/day by a CronJob; worst case a dump
-#      written during rsync is missed and will be picked up by Phase 2
-rsync -a --info=progress2 /bigdisk/LMModels/  /bigdisk/k8s-cluster/models/
-rsync -a --info=progress2 /bigdisk/OpenBrain/ /bigdisk/k8s-cluster/supabase-dumps/
+#    - Supabase dumps are written once/day by a CronJob; worst case a
+#      dump written during the copy is missed and will be picked up by
+#      Phase 2.
+cp -a /share/CACHEDEV1_DATA/bigdisk/LMModels/.  "$ROOT/models/"
+cp -a /share/CACHEDEV1_DATA/bigdisk/OpenBrain/. "$ROOT/supabase-dumps/"
 
-# 5. Normalise ownership on the copied content. rsync preserves source
-#    perms, which may not match the anon UID used by all_squash.
-chown -R 65534:65534 /bigdisk/k8s-cluster/models /bigdisk/k8s-cluster/supabase-dumps
-
-# 6. Verify.
-echo "--- Current exports (should include /bigdisk/k8s-cluster) ---"
-showmount -e localhost
-echo "--- /etc/exports mtime (should be unchanged from before this run) ---"
-stat -c '%y %n' /etc/exports
-echo "--- New drop-in ---"
-cat /etc/exports.d/k8s-cluster.exports
-echo "--- Sizes of copied trees ---"
-du -sh /bigdisk/LMModels /bigdisk/k8s-cluster/models
-du -sh /bigdisk/OpenBrain /bigdisk/k8s-cluster/supabase-dumps
+# 3. Verify — sizes should match within a few MB of metadata.
+echo "--- Old vs new sizes ---"
+du -sh /share/CACHEDEV1_DATA/bigdisk/LMModels  "$ROOT/models"
+du -sh /share/CACHEDEV1_DATA/bigdisk/OpenBrain "$ROOT/supabase-dumps"
+echo "--- Tree ---"
+ls -la "$ROOT" "$ROOT/backups"
 ```
 
-From any cluster node, confirm the export is visible:
+From the cluster devcontainer, confirm the new path is visible over NFS
+before moving on:
 
 ```bash
-showmount -e gknas
-# Should show /bigdisk/k8s-cluster 192.168.1.0/24 alongside the existing
-# shares (LMModels, OpenBrain, JellyFin, etc.) — confirm the existing
-# exports are still listed.
+# Spin a throwaway pod that mounts /bigdisk and lists k8s-cluster.
+kubectl run nas-check --rm -it --restart=Never \
+  --image=busybox:1.36 --overrides='
+{
+  "spec": {
+    "volumes": [{
+      "name": "nas",
+      "nfs": { "server": "192.168.1.3", "path": "/bigdisk" }
+    }],
+    "containers": [{
+      "name": "nas-check",
+      "image": "busybox:1.36",
+      "command": ["sh", "-c", "ls -la /mnt/k8s-cluster /mnt/k8s-cluster/backups"],
+      "volumeMounts": [{ "name": "nas", "mountPath": "/mnt" }]
+    }]
+  }
+}'
 ```
+
+You should see the `models`, `supabase-dumps` and `backups` subtrees.
 
 ## Phase 2 — final sync before rebuild
 
-Re-run this any number of times. It catches any deltas since Phase 1 — in
-practice the only moving parts are the daily Supabase dump and any
-newly-downloaded LLM models. `--delete` turns the target into a true mirror
-of the source, so anything removed upstream is removed from the new share.
-
-Run immediately before `/rebuild-cluster` to minimise the window in which
-new dumps could be missed.
+Re-run this right before `/rebuild-cluster`. It catches any deltas since
+Phase 1 — in practice the only moving parts are the daily Supabase dump
+and any newly-downloaded LLM models. `rsync --delete` turns the target
+into a true mirror of the source, so anything removed upstream is
+removed from the new share too.
 
 ```bash
-set -euo pipefail
+set -eu
+ROOT=/share/CACHEDEV1_DATA/bigdisk/k8s-cluster
 
-rsync -a --delete --info=progress2 /bigdisk/LMModels/  /bigdisk/k8s-cluster/models/
-rsync -a --delete --info=progress2 /bigdisk/OpenBrain/ /bigdisk/k8s-cluster/supabase-dumps/
-chown -R 65534:65534 /bigdisk/k8s-cluster/models /bigdisk/k8s-cluster/supabase-dumps
+rsync -a --delete --info=progress2 \
+  /share/CACHEDEV1_DATA/bigdisk/LMModels/  "$ROOT/models/"
+
+rsync -a --delete --info=progress2 \
+  /share/CACHEDEV1_DATA/bigdisk/OpenBrain/ "$ROOT/supabase-dumps/"
 
 echo "Final sync complete. Safe to run /rebuild-cluster now."
 ```
+
+If the QNAP doesn't have `rsync` on the default PATH, either use its full
+path (`/usr/bin/rsync` on most QTS builds) or fall back to `cp -a`.
 
 ## Rollback
 
@@ -127,26 +176,26 @@ The old paths are never touched by this runbook, so rollback is:
    `/bigdisk/LMModels/cuda` and `/bigdisk/OpenBrain` respectively.
 2. Re-sync ArgoCD. rkllama / llamacpp / supabase-db-data will re-bind to
    the OLD paths and work exactly as before.
-3. Only once no pods are consuming the new share, on the NAS:
+3. Only once no pods are consuming the new tree, on the QNAP:
 
    ```bash
-   rm /etc/exports.d/k8s-cluster.exports
-   exportfs -ra
-   # Optionally, to reclaim space once you're sure you no longer need it:
-   # rm -rf /bigdisk/k8s-cluster
+   rm -rf /share/CACHEDEV1_DATA/bigdisk/k8s-cluster
    ```
+
+   Note that `bigdisk/LMModels` and `bigdisk/OpenBrain` are untouched
+   by the rollback — the copy was additive.
 
 ## What this runbook explicitly DOES NOT do
 
-- Read or write `/etc/exports`.
-- Modify any existing share.
-- Restart `nfs-kernel-server` (only reloads exports via `exportfs -ra`).
-- Touch any path outside `/bigdisk/k8s-cluster/` and
-  `/etc/exports.d/k8s-cluster.exports`.
+- Read or write `/etc/exports` (QNAP-managed — editing breaks the UI).
+- Create or modify any QNAP share or NFS export.
+- Restart any NFS service.
+- Touch any path outside `/share/CACHEDEV1_DATA/bigdisk/k8s-cluster/`.
 - Delete data from the old paths.
 
 ## Adding new cluster-owned subfolders later
 
-Add another `install -d` line by hand on the NAS. No repo change needed for
-directory additions. Export path additions would require editing the drop-in
-file.
+Just `mkdir` under `/share/CACHEDEV1_DATA/bigdisk/k8s-cluster/` by hand.
+No repo change needed for directory additions, and no export changes
+ever — everything the cluster writes lives inside a single subtree of
+the existing `bigdisk` export.

--- a/docs/how-to/nas-setup.md
+++ b/docs/how-to/nas-setup.md
@@ -1,0 +1,152 @@
+# Set Up the Cluster NFS Share on the NAS
+
+This is a **one-time manual runbook** you run by hand on the NAS. Ansible has
+no access to the NAS and this is by design: the NAS hosts unrelated personal
+data (JellyFin libraries, files, etc.) alongside the cluster's NFS shares,
+and we don't want an ansible playbook anywhere near it.
+
+The runbook creates `/bigdisk/k8s-cluster/` — a single new path that contains
+**everything** the cluster reads or writes over NFS:
+
+- `models/` — LLM model files consumed by rkllama and llamacpp
+- `supabase-dumps/` — Supabase database dumps
+- `backups/<app>/` — daily and weekly CronJob backup output
+
+The runbook installs the NFS export as a drop-in (`/etc/exports.d/k8s-cluster.exports`)
+rather than editing `/etc/exports`. The kernel NFS server auto-merges
+everything under `/etc/exports.d/*.exports`, so existing shares are completely
+untouched and rollback is a one-liner.
+
+## Prerequisites
+
+- You can SSH to the NAS as root (or via `sudo -i`).
+- The NAS already runs `nfs-kernel-server` and serves at least one share
+  successfully. (It does if the current cluster's rkllama/llamacpp are working.)
+- `/bigdisk` exists on the NAS and has enough free space to duplicate the
+  existing `LMModels` tree (rsync of the whole models directory).
+- Cluster nodes are all on `192.168.1.0/24`.
+
+## Phase 1 — one-time setup + initial data copy
+
+Run this once on the NAS. It creates the directory tree, installs the
+export drop-in, reloads exports, and rsyncs the existing LLM models and
+Supabase DB dumps from their old paths into the new share.
+
+The old paths (`/bigdisk/LMModels` and `/bigdisk/OpenBrain`) are **preserved
+untouched** — they remain available as a rollback safety net. Do not delete
+them until you are certain the new setup is working in production.
+
+```bash
+set -euo pipefail
+
+# 1. Create the cluster-owned directory tree. Owned by nobody:nogroup
+#    (UID/GID 65534) to match all_squash in the export.
+install -d -o 65534 -g 65534 -m 0755 /bigdisk/k8s-cluster
+install -d -o 65534 -g 65534 -m 0755 /bigdisk/k8s-cluster/models
+install -d -o 65534 -g 65534 -m 0755 /bigdisk/k8s-cluster/supabase-dumps
+install -d -o 65534 -g 65534 -m 0755 /bigdisk/k8s-cluster/backups
+for app in supabase-db supabase-storage supabase-minio grafana open-webui; do
+  install -d -o 65534 -g 65534 -m 0755 "/bigdisk/k8s-cluster/backups/${app}"
+  install -d -o 65534 -g 65534 -m 0755 "/bigdisk/k8s-cluster/backups/${app}/weekly"
+done
+
+# 2. Install the NFS export as a drop-in file. nfs-kernel-server auto-merges
+#    /etc/exports.d/*.exports with /etc/exports — we only write to the
+#    drop-in, so /etc/exports is never touched.
+cat > /etc/exports.d/k8s-cluster.exports <<'EOF'
+# Managed: written by docs/how-to/nas-setup.md from the k3s-ansible repo.
+# Rollback: rm /etc/exports.d/k8s-cluster.exports && exportfs -ra
+/bigdisk/k8s-cluster 192.168.1.0/24(rw,sync,no_subtree_check,root_squash,all_squash,anonuid=65534,anongid=65534,sec=sys)
+EOF
+chmod 0644 /etc/exports.d/k8s-cluster.exports
+
+# 3. Reload exports.
+exportfs -ra
+
+# 4. Initial data copy. Uses rsync -a (preserve perms/times) +
+#    --info=progress2 for a running total. The old paths remain untouched.
+#    These rsyncs are safe to run while the cluster is still using the old
+#    paths:
+#    - LLM models are read-only in practice
+#    - Supabase dumps are written once/day by a CronJob; worst case a dump
+#      written during rsync is missed and will be picked up by Phase 2
+rsync -a --info=progress2 /bigdisk/LMModels/  /bigdisk/k8s-cluster/models/
+rsync -a --info=progress2 /bigdisk/OpenBrain/ /bigdisk/k8s-cluster/supabase-dumps/
+
+# 5. Normalise ownership on the copied content. rsync preserves source
+#    perms, which may not match the anon UID used by all_squash.
+chown -R 65534:65534 /bigdisk/k8s-cluster/models /bigdisk/k8s-cluster/supabase-dumps
+
+# 6. Verify.
+echo "--- Current exports (should include /bigdisk/k8s-cluster) ---"
+showmount -e localhost
+echo "--- /etc/exports mtime (should be unchanged from before this run) ---"
+stat -c '%y %n' /etc/exports
+echo "--- New drop-in ---"
+cat /etc/exports.d/k8s-cluster.exports
+echo "--- Sizes of copied trees ---"
+du -sh /bigdisk/LMModels /bigdisk/k8s-cluster/models
+du -sh /bigdisk/OpenBrain /bigdisk/k8s-cluster/supabase-dumps
+```
+
+From any cluster node, confirm the export is visible:
+
+```bash
+showmount -e gknas
+# Should show /bigdisk/k8s-cluster 192.168.1.0/24 alongside the existing
+# shares (LMModels, OpenBrain, JellyFin, etc.) — confirm the existing
+# exports are still listed.
+```
+
+## Phase 2 — final sync before rebuild
+
+Re-run this any number of times. It catches any deltas since Phase 1 — in
+practice the only moving parts are the daily Supabase dump and any
+newly-downloaded LLM models. `--delete` turns the target into a true mirror
+of the source, so anything removed upstream is removed from the new share.
+
+Run immediately before `/rebuild-cluster` to minimise the window in which
+new dumps could be missed.
+
+```bash
+set -euo pipefail
+
+rsync -a --delete --info=progress2 /bigdisk/LMModels/  /bigdisk/k8s-cluster/models/
+rsync -a --delete --info=progress2 /bigdisk/OpenBrain/ /bigdisk/k8s-cluster/supabase-dumps/
+chown -R 65534:65534 /bigdisk/k8s-cluster/models /bigdisk/k8s-cluster/supabase-dumps
+
+echo "Final sync complete. Safe to run /rebuild-cluster now."
+```
+
+## Rollback
+
+The old paths are never touched by this runbook, so rollback is:
+
+1. Revert `kubernetes-services/values.yaml` — point `rkllama.nfs.path`,
+   `llamacpp.nfs.path` and `supabase.nfs.path` back at `/bigdisk/LMModels`,
+   `/bigdisk/LMModels/cuda` and `/bigdisk/OpenBrain` respectively.
+2. Re-sync ArgoCD. rkllama / llamacpp / supabase-db-data will re-bind to
+   the OLD paths and work exactly as before.
+3. Only once no pods are consuming the new share, on the NAS:
+
+   ```bash
+   rm /etc/exports.d/k8s-cluster.exports
+   exportfs -ra
+   # Optionally, to reclaim space once you're sure you no longer need it:
+   # rm -rf /bigdisk/k8s-cluster
+   ```
+
+## What this runbook explicitly DOES NOT do
+
+- Read or write `/etc/exports`.
+- Modify any existing share.
+- Restart `nfs-kernel-server` (only reloads exports via `exportfs -ra`).
+- Touch any path outside `/bigdisk/k8s-cluster/` and
+  `/etc/exports.d/k8s-cluster.exports`.
+- Delete data from the old paths.
+
+## Adding new cluster-owned subfolders later
+
+Add another `install -d` line by hand on the NAS. No repo change needed for
+directory additions. Export path additions would require editing the drop-in
+file.

--- a/kubernetes-services/additions/backups/Chart.yaml
+++ b/kubernetes-services/additions/backups/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: backups
+description: |
+  Per-app backup CronJobs writing to a single cluster-owned NFS share.
+
+  One static NFS PV maps the whole /bigdisk/k8s-cluster export; each
+  CronJob mounts it with subPath so app-X only sees backups/app-X.
+  Retention is enforced in-job with find -mtime. Daily + weekly schedules
+  per app; prometheus is deliberately not backed up (metrics are
+  reconstructible via re-scrape, not worth the snapshot-API complexity).
+
+  The NFS share itself is created manually on the NAS via
+  docs/how-to/nas-setup.md — ansible has no access to the NAS.
+type: application
+version: 0.1.0

--- a/kubernetes-services/additions/backups/templates/cronjob-grafana-daily.yaml
+++ b/kubernetes-services/additions/backups/templates/cronjob-grafana-daily.yaml
@@ -1,0 +1,52 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: grafana-daily
+  namespace: backups
+spec:
+  schedule: "45 2 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          # Grafana's local PV is pinned to node03.
+          nodeSelector:
+            kubernetes.io/hostname: node03
+          containers:
+            - name: sqlite-backup
+              image: alpine:3.19
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -euo pipefail
+                  apk add --no-cache sqlite tar gzip >/dev/null
+                  stamp=$(date +%F_%H%M)
+                  # Use sqlite3's online .backup for a consistent snapshot
+                  # rather than copying grafana.db while it may be written.
+                  sqlite3 /data/grafana.db ".backup /tmp/grafana.db"
+                  tar -czf "/backup/${stamp}.tar.gz" \
+                    -C /tmp grafana.db \
+                    -C /data provisioning 2>/dev/null || \
+                  tar -czf "/backup/${stamp}.tar.gz" -C /tmp grafana.db
+                  ls -lh /backup
+                  find /backup -maxdepth 1 -type f -name '*.tar.gz' -mtime +7 -delete
+              volumeMounts:
+                - name: data
+                  mountPath: /data
+                  readOnly: true
+                - name: nfs
+                  mountPath: /backup
+                  subPath: backups/grafana
+          volumes:
+            - name: data
+              hostPath:
+                path: /var/lib/k8s-data/grafana
+                type: Directory
+            - name: nfs
+              persistentVolumeClaim:
+                claimName: k8s-cluster-nfs

--- a/kubernetes-services/additions/backups/templates/cronjob-grafana-weekly.yaml
+++ b/kubernetes-services/additions/backups/templates/cronjob-grafana-weekly.yaml
@@ -1,0 +1,49 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: grafana-weekly
+  namespace: backups
+spec:
+  schedule: "45 3 * * 0"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          nodeSelector:
+            kubernetes.io/hostname: node03
+          containers:
+            - name: sqlite-backup
+              image: alpine:3.19
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -euo pipefail
+                  apk add --no-cache sqlite tar gzip >/dev/null
+                  stamp=$(date +%F)
+                  sqlite3 /data/grafana.db ".backup /tmp/grafana.db"
+                  tar -czf "/backup/${stamp}.tar.gz" \
+                    -C /tmp grafana.db \
+                    -C /data provisioning 2>/dev/null || \
+                  tar -czf "/backup/${stamp}.tar.gz" -C /tmp grafana.db
+                  ls -lh /backup
+                  find /backup -maxdepth 1 -type f -name '*.tar.gz' -mtime +28 -delete
+              volumeMounts:
+                - name: data
+                  mountPath: /data
+                  readOnly: true
+                - name: nfs
+                  mountPath: /backup
+                  subPath: backups/grafana/weekly
+          volumes:
+            - name: data
+              hostPath:
+                path: /var/lib/k8s-data/grafana
+                type: Directory
+            - name: nfs
+              persistentVolumeClaim:
+                claimName: k8s-cluster-nfs

--- a/kubernetes-services/additions/backups/templates/cronjob-open-webui-daily.yaml
+++ b/kubernetes-services/additions/backups/templates/cronjob-open-webui-daily.yaml
@@ -1,0 +1,49 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: open-webui-daily
+  namespace: backups
+spec:
+  schedule: "0 3 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          # Open WebUI's local PV is pinned to node04.
+          nodeSelector:
+            kubernetes.io/hostname: node04
+          containers:
+            - name: sqlite-backup
+              image: alpine:3.19
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -euo pipefail
+                  apk add --no-cache sqlite tar gzip >/dev/null
+                  stamp=$(date +%F_%H%M)
+                  # Open WebUI stores its state in /app/backend/data/webui.db
+                  # — matches /data/webui.db via the PV mount point.
+                  sqlite3 /data/webui.db ".backup /tmp/webui.db"
+                  tar -czf "/backup/${stamp}.tar.gz" -C /tmp webui.db
+                  ls -lh /backup
+                  find /backup -maxdepth 1 -type f -name '*.tar.gz' -mtime +7 -delete
+              volumeMounts:
+                - name: data
+                  mountPath: /data
+                  readOnly: true
+                - name: nfs
+                  mountPath: /backup
+                  subPath: backups/open-webui
+          volumes:
+            - name: data
+              hostPath:
+                path: /var/lib/k8s-data/open-webui
+                type: Directory
+            - name: nfs
+              persistentVolumeClaim:
+                claimName: k8s-cluster-nfs

--- a/kubernetes-services/additions/backups/templates/cronjob-open-webui-weekly.yaml
+++ b/kubernetes-services/additions/backups/templates/cronjob-open-webui-weekly.yaml
@@ -1,0 +1,46 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: open-webui-weekly
+  namespace: backups
+spec:
+  schedule: "0 4 * * 0"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          nodeSelector:
+            kubernetes.io/hostname: node04
+          containers:
+            - name: sqlite-backup
+              image: alpine:3.19
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -euo pipefail
+                  apk add --no-cache sqlite tar gzip >/dev/null
+                  stamp=$(date +%F)
+                  sqlite3 /data/webui.db ".backup /tmp/webui.db"
+                  tar -czf "/backup/${stamp}.tar.gz" -C /tmp webui.db
+                  ls -lh /backup
+                  find /backup -maxdepth 1 -type f -name '*.tar.gz' -mtime +28 -delete
+              volumeMounts:
+                - name: data
+                  mountPath: /data
+                  readOnly: true
+                - name: nfs
+                  mountPath: /backup
+                  subPath: backups/open-webui/weekly
+          volumes:
+            - name: data
+              hostPath:
+                path: /var/lib/k8s-data/open-webui
+                type: Directory
+            - name: nfs
+              persistentVolumeClaim:
+                claimName: k8s-cluster-nfs

--- a/kubernetes-services/additions/backups/templates/cronjob-supabase-db-daily.yaml
+++ b/kubernetes-services/additions/backups/templates/cronjob-supabase-db-daily.yaml
@@ -1,0 +1,63 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: supabase-db-daily
+  namespace: backups
+spec:
+  # 02:00 UTC daily. Offset from supabase-storage (02:15) to avoid
+  # both mounting the NFS export at the same moment.
+  schedule: "0 2 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: pgdump
+              image: postgres:15-alpine
+              env:
+                # Helm release name "supabase" is hardcoded here —
+                # if the release is ever renamed, update this URL too.
+                - name: PGHOST
+                  value: supabase-supabase-db.supabase.svc.cluster.local
+                - name: PGPORT
+                  value: "5432"
+                - name: PGUSER
+                  valueFrom:
+                    secretKeyRef:
+                      name: supabase-credentials
+                      key: username
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: supabase-credentials
+                      key: password
+                - name: PGDATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      name: supabase-credentials
+                      key: database
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -euo pipefail
+                  stamp=$(date +%F_%H%M)
+                  out="/backup/${stamp}.sql.gz"
+                  echo "pg_dump → ${out}"
+                  pg_dump --format=plain --no-owner --no-privileges \
+                    | gzip -9 > "${out}"
+                  ls -lh /backup
+                  # Retain 7 days of dailies; weekly cronjob keeps its own retention.
+                  find /backup -maxdepth 1 -type f -name '*.sql.gz' -mtime +7 -delete
+              volumeMounts:
+                - name: nfs
+                  mountPath: /backup
+                  subPath: backups/supabase-db
+          volumes:
+            - name: nfs
+              persistentVolumeClaim:
+                claimName: k8s-cluster-nfs

--- a/kubernetes-services/additions/backups/templates/cronjob-supabase-db-weekly.yaml
+++ b/kubernetes-services/additions/backups/templates/cronjob-supabase-db-weekly.yaml
@@ -1,0 +1,59 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: supabase-db-weekly
+  namespace: backups
+spec:
+  # 03:00 UTC Sunday — runs after all daily jobs have finished.
+  schedule: "0 3 * * 0"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: pgdump
+              image: postgres:15-alpine
+              env:
+                - name: PGHOST
+                  value: supabase-supabase-db.supabase.svc.cluster.local
+                - name: PGPORT
+                  value: "5432"
+                - name: PGUSER
+                  valueFrom:
+                    secretKeyRef:
+                      name: supabase-credentials
+                      key: username
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: supabase-credentials
+                      key: password
+                - name: PGDATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      name: supabase-credentials
+                      key: database
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -euo pipefail
+                  stamp=$(date +%F)
+                  out="/backup/${stamp}.sql.gz"
+                  pg_dump --format=plain --no-owner --no-privileges \
+                    | gzip -9 > "${out}"
+                  ls -lh /backup
+                  # Retain 4 weeks of weeklies (28 days).
+                  find /backup -maxdepth 1 -type f -name '*.sql.gz' -mtime +28 -delete
+              volumeMounts:
+                - name: nfs
+                  mountPath: /backup
+                  subPath: backups/supabase-db/weekly
+          volumes:
+            - name: nfs
+              persistentVolumeClaim:
+                claimName: k8s-cluster-nfs

--- a/kubernetes-services/additions/backups/templates/cronjob-supabase-minio-daily.yaml
+++ b/kubernetes-services/additions/backups/templates/cronjob-supabase-minio-daily.yaml
@@ -1,0 +1,46 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: supabase-minio-daily
+  namespace: backups
+spec:
+  schedule: "30 2 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          nodeSelector:
+            kubernetes.io/hostname: nuc2
+          containers:
+            - name: tar
+              image: alpine:3.19
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -euo pipefail
+                  apk add --no-cache tar gzip >/dev/null
+                  stamp=$(date +%F_%H%M)
+                  out="/backup/${stamp}.tar.gz"
+                  tar -czf "${out}" -C /data .
+                  ls -lh /backup
+                  find /backup -maxdepth 1 -type f -name '*.tar.gz' -mtime +7 -delete
+              volumeMounts:
+                - name: data
+                  mountPath: /data
+                  readOnly: true
+                - name: nfs
+                  mountPath: /backup
+                  subPath: backups/supabase-minio
+          volumes:
+            - name: data
+              hostPath:
+                path: /home/k8s-data/supabase-minio
+                type: Directory
+            - name: nfs
+              persistentVolumeClaim:
+                claimName: k8s-cluster-nfs

--- a/kubernetes-services/additions/backups/templates/cronjob-supabase-minio-weekly.yaml
+++ b/kubernetes-services/additions/backups/templates/cronjob-supabase-minio-weekly.yaml
@@ -1,0 +1,46 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: supabase-minio-weekly
+  namespace: backups
+spec:
+  schedule: "30 3 * * 0"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          nodeSelector:
+            kubernetes.io/hostname: nuc2
+          containers:
+            - name: tar
+              image: alpine:3.19
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -euo pipefail
+                  apk add --no-cache tar gzip >/dev/null
+                  stamp=$(date +%F)
+                  out="/backup/${stamp}.tar.gz"
+                  tar -czf "${out}" -C /data .
+                  ls -lh /backup
+                  find /backup -maxdepth 1 -type f -name '*.tar.gz' -mtime +28 -delete
+              volumeMounts:
+                - name: data
+                  mountPath: /data
+                  readOnly: true
+                - name: nfs
+                  mountPath: /backup
+                  subPath: backups/supabase-minio/weekly
+          volumes:
+            - name: data
+              hostPath:
+                path: /home/k8s-data/supabase-minio
+                type: Directory
+            - name: nfs
+              persistentVolumeClaim:
+                claimName: k8s-cluster-nfs

--- a/kubernetes-services/additions/backups/templates/cronjob-supabase-storage-daily.yaml
+++ b/kubernetes-services/additions/backups/templates/cronjob-supabase-storage-daily.yaml
@@ -1,0 +1,48 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: supabase-storage-daily
+  namespace: backups
+spec:
+  # 02:15 UTC daily — 15 min after supabase-db.
+  schedule: "15 2 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          # Must run on nuc2 — supabase-storage's local PV lives there.
+          nodeSelector:
+            kubernetes.io/hostname: nuc2
+          containers:
+            - name: tar
+              image: alpine:3.19
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -euo pipefail
+                  apk add --no-cache tar gzip >/dev/null
+                  stamp=$(date +%F_%H%M)
+                  out="/backup/${stamp}.tar.gz"
+                  tar -czf "${out}" -C /data .
+                  ls -lh /backup
+                  find /backup -maxdepth 1 -type f -name '*.tar.gz' -mtime +7 -delete
+              volumeMounts:
+                - name: data
+                  mountPath: /data
+                  readOnly: true
+                - name: nfs
+                  mountPath: /backup
+                  subPath: backups/supabase-storage
+          volumes:
+            - name: data
+              hostPath:
+                path: /home/k8s-data/supabase-storage
+                type: Directory
+            - name: nfs
+              persistentVolumeClaim:
+                claimName: k8s-cluster-nfs

--- a/kubernetes-services/additions/backups/templates/cronjob-supabase-storage-weekly.yaml
+++ b/kubernetes-services/additions/backups/templates/cronjob-supabase-storage-weekly.yaml
@@ -1,0 +1,46 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: supabase-storage-weekly
+  namespace: backups
+spec:
+  schedule: "15 3 * * 0"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          nodeSelector:
+            kubernetes.io/hostname: nuc2
+          containers:
+            - name: tar
+              image: alpine:3.19
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -euo pipefail
+                  apk add --no-cache tar gzip >/dev/null
+                  stamp=$(date +%F)
+                  out="/backup/${stamp}.tar.gz"
+                  tar -czf "${out}" -C /data .
+                  ls -lh /backup
+                  find /backup -maxdepth 1 -type f -name '*.tar.gz' -mtime +28 -delete
+              volumeMounts:
+                - name: data
+                  mountPath: /data
+                  readOnly: true
+                - name: nfs
+                  mountPath: /backup
+                  subPath: backups/supabase-storage/weekly
+          volumes:
+            - name: data
+              hostPath:
+                path: /home/k8s-data/supabase-storage
+                type: Directory
+            - name: nfs
+              persistentVolumeClaim:
+                claimName: k8s-cluster-nfs

--- a/kubernetes-services/additions/backups/templates/namespace.yaml
+++ b/kubernetes-services/additions/backups/templates/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: backups

--- a/kubernetes-services/additions/backups/templates/pv.yaml
+++ b/kubernetes-services/additions/backups/templates/pv.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: k8s-cluster-nfs
+spec:
+  capacity:
+    storage: 500Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  claimRef:
+    namespace: backups
+    name: k8s-cluster-nfs
+  nfs:
+    server: "{{ .Values.nfs.server }}"
+    path: "{{ .Values.nfs.cluster_share_path }}"
+  mountOptions:
+    - vers=4.1
+    - hard

--- a/kubernetes-services/additions/backups/templates/pvc.yaml
+++ b/kubernetes-services/additions/backups/templates/pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: k8s-cluster-nfs
+  namespace: backups
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  volumeName: k8s-cluster-nfs
+  resources:
+    requests:
+      storage: 500Gi

--- a/kubernetes-services/additions/local-storage/Chart.yaml
+++ b/kubernetes-services/additions/local-storage/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: local-storage
+description: |
+  Static local PVs and the local-nvme StorageClass.
+
+  Provides node-pinned hostPath PVs that survive cluster rebuild
+  (data lives outside /var/lib/rancher). Each PV is pre-bound via
+  claimRef to the exact PVC a workload chart generates, so the
+  chart-generated PVC re-binds to the same PV after rebuild and the
+  underlying data is preserved.
+
+  See docs/explanations/decisions for the ADR on dropping Longhorn.
+type: application
+version: 0.1.0

--- a/kubernetes-services/additions/local-storage/templates/pv-grafana.yaml
+++ b/kubernetes-services/additions/local-storage/templates/pv-grafana.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: grafana-local
+spec:
+  capacity:
+    storage: 30Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: local-nvme
+  # Grafana is deployed as a StatefulSet (persistence.type=sts) by the
+  # kube-prometheus-stack chart. The PVC name is derived from the STS
+  # volumeClaimTemplate: <vct-name>-<sts-name>-<ordinal>
+  # vct-name = "storage", sts-name = "grafana-prometheus", ordinal = 0.
+  claimRef:
+    namespace: monitoring
+    name: storage-grafana-prometheus-0
+  local:
+    path: /var/lib/k8s-data/grafana
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - node03

--- a/kubernetes-services/additions/local-storage/templates/pv-open-webui.yaml
+++ b/kubernetes-services/additions/local-storage/templates/pv-open-webui.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: open-webui-local
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: local-nvme
+  claimRef:
+    namespace: open-webui
+    name: open-webui
+  local:
+    path: /var/lib/k8s-data/open-webui
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - node04

--- a/kubernetes-services/additions/local-storage/templates/pv-prometheus.yaml
+++ b/kubernetes-services/additions/local-storage/templates/pv-prometheus.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: prometheus-local
+spec:
+  capacity:
+    storage: 40Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: local-nvme
+  # Prometheus Operator generates this PVC name from the StatefulSet
+  # volumeClaimTemplate. The template name itself is derived from the
+  # StatefulSet name, which itself is prefixed with "prometheus-" by the
+  # operator. The resulting PVC name has the prometheus release name
+  # appearing twice (chart name + STS name). Do not "simplify" — this
+  # exact string must match what the operator creates, or the PVC will
+  # not bind to this PV.
+  claimRef:
+    namespace: monitoring
+    name: prometheus-grafana-prometheus-kube-pr-prometheus-db-prometheus-grafana-prometheus-kube-pr-prometheus-0
+  local:
+    path: /var/lib/k8s-data/prometheus
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - node02

--- a/kubernetes-services/additions/local-storage/templates/pv-supabase-db.yaml
+++ b/kubernetes-services/additions/local-storage/templates/pv-supabase-db.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: supabase-db-local
+spec:
+  capacity:
+    storage: 50Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: local-nvme
+  # Pre-bind to the chart-generated PVC. The supabase chart does not
+  # pass `selector` through to its PVCs, so claimRef is the only
+  # reliable way to glue a static PV to a chart-owned PVC.
+  claimRef:
+    namespace: supabase
+    name: supabase-db
+  local:
+    path: /home/k8s-data/supabase-db
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - nuc2

--- a/kubernetes-services/additions/local-storage/templates/pv-supabase-minio.yaml
+++ b/kubernetes-services/additions/local-storage/templates/pv-supabase-minio.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: supabase-minio-local
+spec:
+  capacity:
+    storage: 50Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: local-nvme
+  claimRef:
+    namespace: supabase
+    name: supabase-minio
+  local:
+    path: /home/k8s-data/supabase-minio
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - nuc2

--- a/kubernetes-services/additions/local-storage/templates/pv-supabase-storage.yaml
+++ b/kubernetes-services/additions/local-storage/templates/pv-supabase-storage.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: supabase-storage-local
+spec:
+  capacity:
+    storage: 50Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: local-nvme
+  claimRef:
+    namespace: supabase
+    name: supabase-storage
+  local:
+    path: /home/k8s-data/supabase-storage
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - nuc2

--- a/kubernetes-services/additions/local-storage/templates/storageclass.yaml
+++ b/kubernetes-services/additions/local-storage/templates/storageclass.yaml
@@ -1,0 +1,10 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-nvme
+# No dynamic provisioner — PVs under this class are defined statically
+# in this chart. WaitForFirstConsumer delays binding until a pod is
+# scheduled, so node affinity on the PV is honoured.
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Retain

--- a/kubernetes-services/templates/local-storage.yaml
+++ b/kubernetes-services/templates/local-storage.yaml
@@ -1,0 +1,34 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: local-storage
+  namespace: argo-cd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+  annotations:
+    # Sync before any chart-owned PVC exists (default wave is 0).
+    # The StorageClass + claimRef-bound PVs must already be in the
+    # cluster when supabase, grafana-prometheus and open-webui create
+    # their PVCs, otherwise those PVCs will dynamically provision
+    # against whatever StorageClass is default (local-path) and never
+    # bind to these PVs.
+    argocd.argoproj.io/sync-wave: "-5"
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    # Cluster-scoped resources (StorageClass, PV) don't use this
+    # namespace, but ArgoCD still requires the field.
+    namespace: kube-system
+  project: kubernetes
+  sources:
+    # local-nvme StorageClass + 6 static PVs pre-bound via claimRef
+    # to the PVCs that supabase / grafana-prometheus / open-webui
+    # generate. Data paths are created on the nodes by the
+    # k8s_data_dirs ansible role.
+    - path: ./kubernetes-services/additions/local-storage
+      repoURL: {{ .Values.repo_remote }}
+      targetRevision: {{ .Values.repo_branch }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/pb_all.yml
+++ b/pb_all.yml
@@ -26,6 +26,10 @@
   roles:
     - role: move_fs
     - role: update_packages
+    # Creates /home/k8s-data/* (nuc2) and /var/lib/k8s-data/* (RK1s).
+    # These back the local-nvme PVs and are preserved across rebuilds
+    # by pb_decommission.yml — see roles/k8s_data_dirs/tasks/main.yml.
+    - role: k8s_data_dirs
   become: true
   tags: servers
 

--- a/roles/k8s_data_dirs/tasks/main.yml
+++ b/roles/k8s_data_dirs/tasks/main.yml
@@ -1,0 +1,72 @@
+# Create the host directories that back the local-nvme PVs defined in
+# kubernetes-services/additions/local-storage. Each app has one PV pinned
+# to one specific node, so we create each directory only on its target
+# node using inventory_hostname guards.
+#
+# Paths live outside /var/lib/rancher on purpose: pb_decommission.yml
+# wipes /var/lib/rancher to reset k3s, but these directories are
+# preserved so PVC data survives a cluster rebuild.
+#
+# UIDs: grafana (472) and prometheus (1000/2000) are set from the live
+# cluster's effective securityContext. supabase-db, supabase-storage and
+# open-webui have nil securityContext on the live cluster, so the
+# container image's default UID applies — we use 0777/root as a safe
+# fallback rather than guess. Tighten post-rebuild if a security review
+# asks for it.
+#
+# supabase-minio uses fsGroup 65532, so ownership of 65532:65532 lets
+# the init container's fsGroup chown be a no-op.
+
+- name: Create supabase-db data dir on nuc2
+  ansible.builtin.file:
+    path: /home/k8s-data/supabase-db
+    state: directory
+    owner: root
+    group: root
+    mode: "0777"
+  when: inventory_hostname == 'nuc2'
+
+- name: Create supabase-storage data dir on nuc2
+  ansible.builtin.file:
+    path: /home/k8s-data/supabase-storage
+    state: directory
+    owner: root
+    group: root
+    mode: "0777"
+  when: inventory_hostname == 'nuc2'
+
+- name: Create supabase-minio data dir on nuc2
+  ansible.builtin.file:
+    path: /home/k8s-data/supabase-minio
+    state: directory
+    owner: "65532"
+    group: "65532"
+    mode: "0755"
+  when: inventory_hostname == 'nuc2'
+
+- name: Create prometheus data dir on node02
+  ansible.builtin.file:
+    path: /var/lib/k8s-data/prometheus
+    state: directory
+    owner: "1000"
+    group: "2000"
+    mode: "0755"
+  when: inventory_hostname == 'node02'
+
+- name: Create grafana data dir on node03
+  ansible.builtin.file:
+    path: /var/lib/k8s-data/grafana
+    state: directory
+    owner: "472"
+    group: "472"
+    mode: "0755"
+  when: inventory_hostname == 'node03'
+
+- name: Create open-webui data dir on node04
+  ansible.builtin.file:
+    path: /var/lib/k8s-data/open-webui
+    state: directory
+    owner: root
+    group: root
+    mode: "0777"
+  when: inventory_hostname == 'node04'


### PR DESCRIPTION
## Summary

First PR of a two-step plan to replace Longhorn with static local PVs + NFS backups. **Non-disruptive**: nothing switches off Longhorn, no workload PVCs change StorageClass, the live cluster keeps running unchanged. PR2 will flip supabase/grafana/open-webui to \`local-nvme\`, add the backups ArgoCD Application, migrate NFS paths, and delete Longhorn.

Plan: \`/root/.claude/plans/recursive-dancing-hammock.md\`.

- \`kubernetes-services/additions/local-storage/\` — \`local-nvme\` StorageClass (no-provisioner, WFFC, Retain) + 6 static PVs with \`claimRef\` pre-bound to the chart-generated PVCs in supabase, monitoring, and open-webui. Node affinity: supabase → nuc2, prometheus → node02, grafana → node03, open-webui → node04.
- \`kubernetes-services/templates/local-storage.yaml\` — ArgoCD Application, sync-wave \`-5\`.
- \`roles/k8s_data_dirs/\` — idempotent role creating the hostPath dirs. Grafana 472:472, prometheus 1000:2000, supabase-minio 65532:65532 (taken from live cluster securityContexts). supabase-db / supabase-storage / open-webui use root/0777 as a safe fallback because their live pods have \`nil\` securityContext.
- \`pb_all.yml\` — \`k8s_data_dirs\` wired into the \`servers\` play after \`update_packages\`.
- \`kubernetes-services/additions/backups/\` — chart source for 10 backup CronJobs (5 apps × daily + weekly) writing to a single NFS PV via \`subPath\`. Supabase-db uses \`pg_dump\`; sqlite workloads use \`sqlite3 .backup\`; file stores use \`tar\`. The Application template is **deliberately omitted** — the chart needs the new NFS share to exist on the NAS first.
- \`docs/how-to/nas-setup.md\` — manual runbook for the NAS. Phase 1 creates \`/bigdisk/k8s-cluster\`, installs a drop-in export under \`/etc/exports.d/\` (never touches \`/etc/exports\`), and rsyncs LLM models + Supabase dumps into the new tree. Phase 2 is the pre-rebuild final sync. Ansible never touches the NAS by design — it hosts unrelated personal data (JellyFin etc.).
- \`docs/explanations/ansible-roles.md\` — catalog entry for the new role.

## Test plan

- [ ] \`helm template\` both new charts render cleanly (verified locally: 7 resources in local-storage, 10 CronJobs in backups)
- [ ] \`ansible-lint\` passes on \`roles/k8s_data_dirs/\` (verified locally)
- [ ] Pre-commit hooks pass (yamllint, secret scan, ansible-lint — all green)
- [ ] Review: \`claimRef\` namespace/name in each PV matches the chart-generated PVC names on the live cluster:
  - \`supabase/supabase-db\`, \`supabase/supabase-storage\`, \`supabase/supabase-minio\` ✓
  - \`monitoring/storage-grafana-prometheus-0\` ✓
  - \`monitoring/prometheus-grafana-prometheus-kube-pr-prometheus-db-prometheus-grafana-prometheus-kube-pr-prometheus-0\` ✓ (operator-generated; do not "simplify")
  - \`open-webui/open-webui\` ✓
- [ ] Review: UIDs in \`k8s_data_dirs\` against footgun #1 in the plan
- [ ] Sanity: \`git grep -n longhorn\` — Longhorn references should be unchanged in this PR (cutover is PR2)

## Out of scope (moved to PR2)

- Flipping \`storageClassName: longhorn\` → \`local-nvme\` in supabase/grafana/open-webui
- Removing the \`NotIn ws03\` affinity blocks (redundant once local PV affinity exists)
- Deleting \`kubernetes-services/additions/longhorn/\` and \`kubernetes-services/templates/longhorn.yaml\`
- Updating \`kubernetes-services/values.yaml\` NFS paths to \`/bigdisk/k8s-cluster/*\`
- Adding the backups ArgoCD Application template
- \`pb_decommission.yml\` surgery (Longhorn teardown + preserve-local-data guard)
- Doc updates in \`docs/how-to/backup-restore.md\`, \`alternative-storage.md\`, \`PLAN.md\`, \`CLAUDE.md\`, new ADR

🤖 Generated with [Claude Code](https://claude.com/claude-code)