### PR TITLE
gitignore: exclude .claude/scheduled_tasks.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 **/*.code-workspace
 nohup.out
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 .mcp.json
 .ansible/
 


### PR DESCRIPTION
## Summary
- Claude Code harness creates `.claude/scheduled_tasks.lock` at runtime (JSON: `{sessionId, pid, acquiredAt}`) when `ScheduleWakeup` is called, to coordinate scheduled-task ownership between sessions.
- It was appearing as untracked in every dev session that used scheduled wakeups — pure runtime state, never repo content.

## Test plan
- [x] File no longer shows in `git status` after ignore added
- [x] Other tracked `.claude/` contents (commands/, skills/, settings.json) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)