### PR TITLE
home: replace Longhorn LAN probe with home-lan hostname

### DIFF
--- a/kubernetes-services/additions/home/templates/manifests.yaml
+++ b/kubernetes-services/additions/home/templates/manifests.yaml
@@ -154,10 +154,6 @@ data:
           <h2>Open WebUI<span class="badge badge-sso">SSO</span></h2>
           <p>LLM chat interface</p>
         </a>
-        <a class="card card-lan" href="https://longhorn.{{ .Values.cluster_domain }}">
-          <h2>Longhorn<span class="badge badge-oauth">OAuth</span><span class="badge badge-lan lan-badge">LAN only</span></h2>
-          <p>Distributed block storage management</p>
-        </a>
         <a class="card" href="https://supabase.{{ .Values.cluster_domain }}">
           <h2>Supabase Studio<span class="badge badge-oauth">OAuth</span></h2>
           <p>Database and backend management</p>
@@ -173,11 +169,11 @@ data:
       </div>
       <h2 class="section-heading">Network</h2>
       <div class="grid">
-        <a class="card card-lan" href="http://192.168.1.1">
+        <a class="card card-lan disabled" href="http://192.168.1.1">
           <h2>OpenWRT<span class="badge badge-lan lan-badge">LAN only</span></h2>
           <p>Network router administration</p>
         </a>
-        <a class="card card-lan" href="http://192.168.1.92:8096/web/#/home">
+        <a class="card card-lan disabled" href="http://192.168.1.92:8096/web/#/home">
           <h2>JellyFin<span class="badge badge-lan lan-badge">LAN only</span></h2>
           <p>Media server</p>
         </a>
@@ -198,18 +194,20 @@ data:
       </div>
       <script>
         (function() {
-          function disableLan() {
+          function enableLan() {
             document.querySelectorAll('.card-lan').forEach(function(el) {
-              el.classList.add('disabled');
+              el.classList.remove('disabled');
             });
           }
-          // Probe Longhorn (LAN-only) to detect network. Fetch in no-cors
-          // mode: resolves if TCP connects (on LAN), rejects otherwise.
+          // Probe home-lan (grey-clouded LAN-only hostname) to detect network.
+          // Fetch in no-cors mode: resolves if TCP connects (on LAN), rejects
+          // otherwise. LAN cards start disabled in the HTML so WAN visitors
+          // never see a flash of active links; we only enable on success.
           var ctrl = new AbortController();
-          var timer = setTimeout(function() { ctrl.abort(); disableLan(); }, 3000);
-          fetch('https://longhorn.{{ .Values.cluster_domain }}/', {mode:'no-cors', signal:ctrl.signal})
-            .then(function() { clearTimeout(timer); })
-            .catch(function() { clearTimeout(timer); disableLan(); });
+          var timer = setTimeout(function() { ctrl.abort(); }, 3000);
+          fetch('https://home-lan.{{ .Values.cluster_domain }}/healthz', {mode:'no-cors', signal:ctrl.signal})
+            .then(function() { clearTimeout(timer); enableLan(); })
+            .catch(function() { clearTimeout(timer); });
         })();
       </script>
     </body>

--- a/kubernetes-services/templates/home.yaml
+++ b/kubernetes-services/templates/home.yaml
@@ -32,6 +32,21 @@ spec:
           service_port: 80
           oauth2_proxy: false
           ssl_redirect: {{ if .Values.enable_cloudflare_tunnel }}false{{ else }}true{{ end }}
+
+    # LAN-only probe endpoint. Backs the same home service at a grey-clouded
+    # hostname so the landing page's JS can detect "am I on the LAN" by
+    # fetching /healthz — TCP connects only when the client is on the LAN.
+    - path: ./kubernetes-services/additions/ingress
+      repoURL: {{ .Values.repo_remote }}
+      targetRevision: {{ .Values.repo_branch }}
+      helm:
+        valuesObject:
+          name: home-lan
+          cluster_domain: {{ .Values.cluster_domain }}
+          service_name: home
+          service_port: 80
+          oauth2_proxy: false
+          ssl_redirect: {{ if .Values.enable_cloudflare_tunnel }}false{{ else }}true{{ end }}
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
## Summary
- Longhorn was removed in #324, so the landing page's LAN-detection probe against `longhorn.<cluster_domain>` now fails for everyone and LAN cards stay permanently disabled.
- Add a dedicated grey-clouded hostname `home-lan.<cluster_domain>` backed by the existing `home` nginx `/healthz` endpoint via a second invocation of the ingress sub-chart. cert-manager's DNS-01 Cloudflare solver mints the cert automatically.
- Invert the detection logic: LAN cards are marked `disabled` in the HTML by default and JS *enables* them on successful probe. Removes the 3 s flash of active-looking links WAN visitors used to see, and reduces LAN detection to a single round-trip.
- Drop the dead Longhorn card from the landing page.

## Manual prerequisite
Grey-cloud A record `home-lan.<cluster_domain>` → same LAN ingress IP as the old Longhorn record, created in the Cloudflare dashboard. (Already done for this cluster.)

## Test plan
- [ ] `just switch-branch home/lan-probe-home-lan` and run `ansible-playbook pb_all.yml --tags cluster -e repo_branch=home/lan-probe-home-lan`
- [ ] `kubectl -n home get ingress home-lan-ingress` shows the host and a Ready cert
- [ ] `curl https://home-lan.<cluster_domain>/healthz` from LAN returns `ok`
- [ ] Open `https://home.<cluster_domain>` on LAN — OpenWRT and JellyFin cards become active within ~1 s
- [ ] Open the same page on cellular — LAN cards stay greyed the entire session, no flash of active state
- [ ] Longhorn card is gone from the grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)