### PR TITLE
docs: sweep Longhorn references post-drop cutover

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,15 @@ Documentation   | <https://gilesknap.github.io/tpi-k3s-ansible>
 - **Ingress + TLS** — NGINX ingress with Let's Encrypt certificates
   (DNS-01 via Cloudflare)
 - **OIDC authentication** — ArgoCD Dex with GitHub connector provides native
-  OIDC for ArgoCD, Grafana, and Open WebUI; oauth2-proxy covers Longhorn,
-  Headlamp, and Supabase Studio
+  OIDC for ArgoCD, Grafana, and Open WebUI; oauth2-proxy covers Headlamp
+  and Supabase Studio
 - **Cloudflare Tunnel + Access** — optional secure public access via
   cloudflared with email-based access control
 
 ### Services
 
 - **Monitoring** — Prometheus + Grafana stack
-- **Distributed storage** — Longhorn with snapshots and backup
+- **Persistent storage** — static `local-nvme` PVs per host, with daily/weekly NFS backup CronJobs to a NAS
 - **Kubernetes dashboard** — Headlamp with RBAC
 - **Supabase** — self-hosted backend with PostgreSQL + pgvector, Auth, Storage
   (MinIO-backed), and Studio UI

--- a/docs/_static/architecture.html
+++ b/docs/_static/architecture.html
@@ -844,16 +844,17 @@ body {
           }
         },
         {
-          icon: '\uD83D\uDCBE', name: 'Longhorn',
-          desc: 'Distributed block storage',
+          icon: '\uD83D\uDCBE', name: 'local-nvme PVs + NFS backups',
+          desc: 'Static host PVs with CronJob backups to NAS',
           modal: {
-            oneliner: 'Cloud-native distributed block storage for Kubernetes.',
+            oneliner: 'Static local-nvme PVs per host, backed up nightly to NAS via CronJobs.',
             features: [
-              'Replicated volumes across nodes',
-              'Snapshot and backup support',
-              'Web UI for volume management'
+              'One static PersistentVolume per stateful pod, pinned by node affinity',
+              'Data directories live under /home/k8s-data (nuc2) and /var/lib/k8s-data (RK1 nodes)',
+              'Daily and weekly backup CronJobs dump data to an NFS share on the NAS',
+              'Survives cluster rebuilds unless wipe_local_data=true is passed explicitly'
             ],
-            rationale: 'Simpler than Rook-Ceph, lower resource overhead, good for small clusters.',
+            rationale: 'Lower overhead and simpler failure modes than distributed block storage; reuses the existing NAS for durability.',
             link: 'explanations/architecture.html'
           }
         },
@@ -898,7 +899,7 @@ body {
           modal: {
             oneliner: 'Authentication gateway for services that do not support OIDC natively.',
             features: [
-              'Protects Longhorn UI, Supabase Studio, and other services',
+              'Protects Supabase Studio and Headlamp',
               'Email-based access control list',
               'Cookie-based session management'
             ],
@@ -949,7 +950,7 @@ body {
               'Prometheus scrapes cluster, node, and application metrics',
               'Grafana dashboards for visualization',
               'Alertmanager for notification routing',
-              'Persistent storage via Longhorn PVCs'
+              'Persistent storage via static local-nvme PVs'
             ],
             rationale: 'Industry-standard observability stack with mature ecosystem.',
             link: 'explanations/architecture.html'

--- a/docs/explanations/ansible-roles.md
+++ b/docs/explanations/ansible-roles.md
@@ -47,7 +47,7 @@ Also creates:
 
 - Shell completions for helm, kubectl (bash + zsh)
 - `k` alias for kubectl
-- Port-forward helper scripts: `argo.sh`, `grafana.sh`, `dashboard.sh`, `longhorn.sh`
+- Port-forward helper scripts: `argo.sh`, `grafana.sh`, `dashboard.sh`
 - Sets PATH to include `$BIN_DIR`
 
 The role is split across multiple task files:
@@ -152,7 +152,6 @@ Prepares each node for K3s:
 4. `apt autoremove` (clean up)
 5. Install required packages:
    - `unattended-upgrades` — automatic security updates
-   - `open-iscsi` — required by Longhorn for iSCSI storage
    - `original-awk` — required by some K3s scripts
 6. **NVIDIA GPU nodes only** (when `nvidia_gpu_node: true` in inventory):
    - Install `ubuntu-drivers-common` and run `ubuntu-drivers install` to install the GPU driver

--- a/docs/explanations/architecture.md
+++ b/docs/explanations/architecture.md
@@ -30,7 +30,7 @@ flowchart TB
     subgraph Cluster["K3s Cluster"]
         K3S[K3s Control Plane]
         ARGO[ArgoCD]
-        SVC[Services<br/>cert-manager, ingress-nginx,<br/>Longhorn, Grafana, Supabase,<br/>Open Brain, etc.]
+        SVC[Services<br/>cert-manager, ingress-nginx,<br/>Grafana, Supabase,<br/>Open Brain, etc.]
     end
 
     subgraph Git["Git Repository"]
@@ -120,7 +120,7 @@ ArgoCD continuously reconciles the cluster state with the repository. See
 | K3s over K8s | Lightweight, single binary, ideal for ARM and small clusters |
 | ArgoCD over Flux | Mature, excellent UI, widely adopted |
 | NGINX Ingress over Traefik | More widely documented, better TLS passthrough support |
-| Longhorn over Rook-Ceph | Simpler, lower resource overhead, good for small clusters |
+| Static `local-nvme` PVs + NFS backup CronJobs over distributed block storage | Lower overhead, simpler failure modes, known host pinning; the NAS was already present so backups reuse existing infrastructure |
 | cert-manager + DNS-01 | Works for LAN-only services that have no public HTTP route |
 | Sealed Secrets over SOPS | Kubernetes-native, no external key management needed |
 | DevContainer over bare metal | Reproducible execution environment, zero host contamination |

--- a/docs/explanations/authentication.md
+++ b/docs/explanations/authentication.md
@@ -53,7 +53,6 @@ Dex OIDC but receive only read-only access.
 | Grafana | Cloudflare Access | Dex (`generic_oauth`) | email → `Admin` / `Viewer` |
 | Open WebUI | Cloudflare Access | Dex (native OIDC) | email → admin / user |
 | Headlamp | Cloudflare Access | oauth2-proxy + ServiceAccount token | — |
-| Longhorn | Cloudflare Access | oauth2-proxy | None (full access after auth) |
 | Supabase Studio | Cloudflare Access | oauth2-proxy | Dashboard password |
 | Echo | Cloudflare Access | None | None (public test service) |
 | Open Brain MCP | Cloudflare Access | OAuth 2.1 (GitHub) | x-brain-key |
@@ -191,11 +190,11 @@ follow the 301 redirect from `/api/dex` to `/api/dex/`.
 ### Headlamp — oauth2-proxy + ServiceAccount token
 
 Headlamp is protected by the cluster-wide oauth2-proxy (admin-only,
-same as Longhorn and Supabase Studio). After authenticating via GitHub,
+same as Supabase Studio). After authenticating via GitHub,
 users paste a Kubernetes ServiceAccount token to access the dashboard.
 The token is generated with `kubectl create token headlamp -n headlamp`.
 
-### oauth2-proxy services — Headlamp, Longhorn, Supabase Studio
+### oauth2-proxy services — Headlamp and Supabase Studio
 
 Services without native OIDC support use the cluster-wide oauth2-proxy.
 This is a separate authentication path that goes directly to GitHub (not
@@ -210,7 +209,7 @@ sequenceDiagram
     participant GitHub
     participant Svc as Backend service
 
-    User->>NGINX: Visit longhorn.<domain>
+    User->>NGINX: Visit supabase-studio.<domain>
     NGINX->>OAP: Auth subrequest
     OAP-->>NGINX: 401 (not authenticated)
     NGINX->>User: Redirect to oauth2.<domain>
@@ -264,7 +263,6 @@ flowchart TB
 
         subgraph ProxyAuth["oauth2-proxy (admin only)"]
             Headlamp
-            Longhorn
             Supabase[Supabase Studio]
         end
 
@@ -284,7 +282,6 @@ flowchart TB
     NGINX --> Grafana
     NGINX --> OpenWebUI
     NGINX --> Headlamp
-    NGINX --> Longhorn
     NGINX --> Supabase
     NGINX --> Echo
 
@@ -293,7 +290,6 @@ flowchart TB
     Grafana <-.-> DexPod
     OpenWebUI <-.-> DexPod
     Headlamp <-.-> OAP
-    Longhorn <-.-> OAP
     Supabase <-.-> OAP
 
     DexPod <-.-> GH
@@ -320,7 +316,7 @@ viewer_emails:
 
 | Template / Config | Effect |
 |-------------------|--------|
-| `oauth2-proxy.yaml` | Email allowlist — only admins can access Longhorn, Supabase Studio |
+| `oauth2-proxy.yaml` | Email allowlist — only admins can access Supabase Studio and Headlamp |
 | `grafana.yaml` | `role_attribute_path` — admin emails get `Admin`, others get `Viewer` |
 | `open-webui.yaml` | `OAUTH_ADMIN_EMAIL` — admin emails get admin role |
 | `argocd-rbac-cm.yml` | `g, <email>, role:admin` — admin emails get ArgoCD admin |
@@ -328,8 +324,7 @@ viewer_emails:
 
 **Viewer emails** authenticate via Dex OIDC and receive read-only roles:
 ArgoCD `role:readonly`, Grafana `Viewer`, Open WebUI `user`. They
-cannot access oauth2-proxy-gated services (Longhorn, Supabase Studio)
-or oauth2-proxy-gated services (Headlamp).
+cannot access oauth2-proxy-gated services (Headlamp, Supabase Studio).
 
 :::{important}
 `admin_emails` must be kept in sync in two places:
@@ -364,13 +359,13 @@ watched).
 tokens with scopes and claims, enabling fine-grained RBAC (admin vs
 viewer). Services with native OIDC support (ArgoCD, Grafana, Open WebUI) use
 Dex for authentication, which allows both admin and viewer users to log
-in with differentiated roles. Services without native OIDC (Longhorn,
-Supabase Studio) use oauth2-proxy as a binary admin-only gate. Headlamp
+in with differentiated roles. Services without native OIDC (Supabase
+Studio) use oauth2-proxy as a binary admin-only gate. Headlamp
 uses ServiceAccount token auth for simplicity.
 
 **Why is oauth2-proxy admin-only?** oauth2-proxy has no concept of roles —
-it either allows or denies an email. Since Longhorn and Supabase Studio
-have no app-level RBAC, giving viewer users access would grant them full
+it either allows or denies an email. Since Supabase Studio has no
+app-level RBAC, giving viewer users access would grant them full
 admin capabilities. Restricting oauth2-proxy to `admin_emails` ensures
 only trusted operators can reach these destructive admin tools.
 

--- a/docs/explanations/security.md
+++ b/docs/explanations/security.md
@@ -33,7 +33,6 @@ Dex OIDC or oauth2-proxy (ingress auth), and per-service RBAC. See
 | Grafana | Cloudflare Access | Dex (`generic_oauth`) | email → Admin / Viewer |
 | Open WebUI | Cloudflare Access | Dex (native OIDC) | email → admin / user |
 | Headlamp | Cloudflare Access | oauth2-proxy + token | — |
-| Longhorn | Cloudflare Access | oauth2-proxy | None |
 | Supabase Studio | Cloudflare Access | oauth2-proxy | Dashboard password |
 | Echo | Cloudflare Access | None | None (public test) |
 | RKLlama | — | None | Internal API (fronted by Open WebUI) |

--- a/docs/how-to/accessing-services.md
+++ b/docs/how-to/accessing-services.md
@@ -51,19 +51,6 @@ disabled. Emails in the `oauth2_emails` list get the Admin role; everyone
 else gets Viewer. Grafana comes preconfigured with the
 `kube-prometheus-stack` dashboards for cluster monitoring.
 
-## Longhorn UI
-
-Via ingress: **https://longhorn.\<domain\>** (oauth2-proxy login)
-
-Via port-forward:
-
-```bash
-longhorn.sh
-```
-
-Authenticate via GitHub (oauth2-proxy). The UI shows storage volumes,
-replicas, and backup status.
-
 ## Headlamp (Kubernetes Dashboard)
 
 Via ingress: **https://headlamp.\<domain\>**

--- a/docs/how-to/add-remove-services.md
+++ b/docs/how-to/add-remove-services.md
@@ -152,7 +152,7 @@ Application, including its namespace if it was created by `CreateNamespace=true`
 
 Most services in this project use multi-source Applications — combining a Helm chart
 from an external repository with local additions from this repo. This pattern is used
-for services like `cert-manager`, `grafana`, and `longhorn`.
+for services like `cert-manager`, `grafana`, and `ingress-nginx`.
 
 Example from `grafana.yaml` (simplified):
 

--- a/docs/how-to/alternative-storage.md
+++ b/docs/how-to/alternative-storage.md
@@ -116,8 +116,10 @@ spec:
 ```
 
 Add `https://charts.longhorn.io/` to `sourceRepos` in
-`argo-cd/argo-project.yaml`, and re-add `open-iscsi` to the `update_packages`
-role's package list (Longhorn needs it for iSCSI target presentation).
+`argo-cd/argo-project.yaml`. If you choose Longhorn, you also need to add
+`open-iscsi` to the `update_packages` role's package list — Longhorn
+requires it for iSCSI target presentation, and it is no longer installed
+by default because the cluster dropped Longhorn.
 
 ### Dynamic NFS CSI
 

--- a/docs/how-to/bootstrap-cluster.md
+++ b/docs/how-to/bootstrap-cluster.md
@@ -20,8 +20,8 @@ just set-admin-password
 ```
 
 This prompts for a password (or reads ``ADMIN_PASSWORD`` from the environment),
-creates the ``admin-auth`` secret in the ``longhorn`` and ``monitoring``
-namespaces, patches the ArgoCD admin password, and restarts the ArgoCD server.
+creates the ``admin-auth`` secret in the ``monitoring`` namespace (used by
+Grafana), patches the ArgoCD admin password, and restarts the ArgoCD server.
 
 To update the password later, re-run the same command and restart cached
 services:

--- a/docs/how-to/cloudflare-tunnel.md
+++ b/docs/how-to/cloudflare-tunnel.md
@@ -27,7 +27,7 @@ cloudflared pod (in cluster, outbound connection only — no inbound firewall po
 ingress-nginx → service
 
 LAN ACCESS (all services)
-  DNS: grafana/argocd/headlamp/longhorn/rkllama.<domain> → worker IP  (DNS-only A records)
+  DNS: grafana/argocd/headlamp/rkllama.<domain> → worker IP  (DNS-only A records)
   Clients resolve directly to ingress-nginx without going via Cloudflare
 ```
 
@@ -124,7 +124,7 @@ Cloudflare will round-robin across them:
 
 Replace the IPs with the LAN addresses of your worker nodes (e.g.
 `192.168.1.82`, `.83`, `.84`). Services to add: `argocd`, `grafana`,
-`headlamp`, `longhorn`, `oauth2`, `open-webui`, `rkllama`.
+`headlamp`, `oauth2`, `open-webui`, `rkllama`.
 
 These resolve to private RFC-1918 addresses — only reachable from your LAN.
 For a single-node cluster, one A record per service is sufficient.

--- a/docs/how-to/cloudflare-web-tunnel.md
+++ b/docs/how-to/cloudflare-web-tunnel.md
@@ -65,8 +65,6 @@ Before exposing services, consider the risk profile of each:
 
 **Services deliberately excluded:**
 
-- **Longhorn** — no native authentication. If OAuth is bypassed, an attacker gets
-  full storage admin access. Keep it LAN-only.
 - **RKLlama** — internal API consumed by Open WebUI. No reason to expose directly.
 
 **Overall risk assessment:** The combination of Cloudflare Access + oauth2-proxy +

--- a/docs/how-to/monitoring.md
+++ b/docs/how-to/monitoring.md
@@ -41,15 +41,15 @@ Prometheus discovers scrape targets via **ServiceMonitor** resources. The
 kube-prometheus-stack automatically creates ServiceMonitors for core Kubernetes
 components.
 
-Additional services can be monitored by creating their own ServiceMonitor. For example,
-Longhorn has `serviceMonitor.enabled: true` in its Helm values, which creates a
-ServiceMonitor for Longhorn metrics.
+Additional services can be monitored by creating their own ServiceMonitor — set
+`serviceMonitor.enabled: true` in the service's Helm values (where supported) or
+ship a ServiceMonitor manifest alongside the app.
 
 ## Data retention
 
-Prometheus stores metrics data in a Longhorn persistent volume (40Gi by default,
-configured in `kubernetes-services/templates/grafana.yaml`). Default retention is 10
-days (kube-prometheus-stack default).
+Prometheus stores metrics data on a static `local-nvme` PV on node02 (40Gi by
+default, configured in `kubernetes-services/templates/grafana.yaml`). Default
+retention is 10 days (kube-prometheus-stack default).
 
 To change retention, add to the Prometheus Helm values:
 

--- a/docs/how-to/oauth-setup.md
+++ b/docs/how-to/oauth-setup.md
@@ -9,7 +9,7 @@ This guide walks through configuring both authentication paths used by the
 cluster:
 
 - **Part A** — Dex OIDC (ArgoCD, Grafana, Open WebUI, argocd-monitor)
-- **Part B** — oauth2-proxy (Longhorn, Supabase Studio — admin-only)
+- **Part B** — oauth2-proxy (Supabase Studio, Headlamp — admin-only)
 
 ```{mermaid}
 flowchart LR
@@ -25,8 +25,8 @@ flowchart LR
     DEX --> Open-WebUI
     DEX --> argocd-monitor
 
-    OAP --> Longhorn
     OAP --> Supabase
+    OAP --> Headlamp
 ```
 
 ## Prerequisites
@@ -246,8 +246,8 @@ oauth2-proxy before forwarding each request.
 
 Services protected by oauth2-proxy (admin-only):
 
-- **Longhorn** — no native auth; OAuth is the only access control
 - **Supabase Studio** — requires a dashboard password after OAuth login
+- **Headlamp** — uses OAuth as the outer access control layer
 
 ---
 
@@ -269,7 +269,7 @@ ingress values.
 
 ### 403 after GitHub login
 
-For oauth2-proxy services (Longhorn, Supabase Studio): the email must be
+For oauth2-proxy services (Headlamp, Supabase Studio): the email must be
 in `admin_emails` in `values.yaml`. Viewer users cannot access these services
 by design.
 

--- a/docs/how-to/open-brain.md
+++ b/docs/how-to/open-brain.md
@@ -14,8 +14,9 @@ container images do not reliably support ARM64.
 ## Prerequisites
 
 - An x86/amd64 node in your cluster (any node with `kubernetes.io/arch: amd64`)
-- An NFS export for database backups (optional — the database uses Longhorn
-  by default)
+- An NFS export for database backups (used by the daily/weekly backup
+  CronJobs — the Supabase database itself runs on a static `local-nvme`
+  PV on nuc2)
 - [Cloudflare Tunnel](cloudflare-web-tunnel) configured (for external access)
 - [OAuth2 proxy](oauth-setup) configured (for Studio dashboard access)
 
@@ -37,9 +38,11 @@ enable_open_brain_mcp: true
 ```
 
 :::{tip}
-The NFS settings are currently used only by the additions chart for potential
-future storage needs. The PostgreSQL database uses Longhorn block storage,
-which is more reliable for database workloads.
+The NFS export is used by the daily/weekly backup CronJobs in the `backups`
+namespace — they dump `supabase-db` to NAS as compressed SQL files. The
+live Supabase PostgreSQL database, Storage and MinIO all run on static
+`local-nvme` PVs pinned to nuc2, which is more reliable for database
+workloads than networked storage.
 :::
 
 ## 2 -- Generate and seal credentials
@@ -307,7 +310,7 @@ through the context window.
 
 Open Brain supports saving file attachments alongside thoughts using MinIO
 as an S3-compatible object store. Files are stored in a private Supabase
-Storage bucket (`brain-attachments`) backed by a Longhorn PVC.
+Storage bucket (`brain-attachments`) backed by a `local-nvme` PVC on nuc2.
 
 ### How it works
 
@@ -326,7 +329,8 @@ this feature was added, verify that `deployment.minio.enabled: true` is set in
 `kubernetes-services/templates/supabase.yaml`. After pushing the change, ArgoCD
 will deploy MinIO automatically.
 
-The MinIO pod needs its own Longhorn PVC. Verify it is provisioned:
+The MinIO pod needs its own `local-nvme` PVC on nuc2. Verify it is
+provisioned and bound:
 
 ```bash
 kubectl get pvc -n supabase | grep minio
@@ -344,8 +348,11 @@ sealed secret.
 
 To remove Supabase from your cluster, set `enable_supabase: false` in
 `kubernetes-services/values.yaml`, commit, push, and re-run the playbook.
-ArgoCD will prune all Supabase resources. The Longhorn PVC retains your
-data until manually deleted.
+ArgoCD will prune the Supabase Application resources, but the underlying
+data directories on nuc2 (`/home/k8s-data/supabase-db`,
+`/home/k8s-data/supabase-storage`, `/home/k8s-data/supabase-minio`) are
+preserved across rebuilds and are only removed if you explicitly pass
+`-e wipe_local_data=true` to `pb_decommission.yml`.
 
 ## Troubleshooting
 
@@ -367,8 +374,9 @@ Always include both headers:
 
 If the DB pod fails with `chown: Operation not permitted`, the storage
 backend does not support ownership changes. The default configuration uses
-Longhorn which handles this correctly. If you switched to NFS, you need
-`no_root_squash` on the NFS export.
+a static `local-nvme` PV on nuc2 (backed by a plain hostPath under
+`/home/k8s-data/supabase-db`), which handles ownership changes correctly.
+If you switched to NFS, you need `no_root_squash` on the NFS export.
 
 ### ArgoCD "not permitted in project"
 

--- a/docs/how-to/reflash-rebuild.md
+++ b/docs/how-to/reflash-rebuild.md
@@ -40,8 +40,11 @@ ansible-playbook pb_all.yml --tags k3s,cluster -e k3s_force=true
 ```
 
 This uninstalls K3s from every node, reinstalls it, and redeploys ArgoCD and all services.
-Persistent volume data on NVMe/Longhorn will survive if the underlying storage is not
-reformatted.
+Stateful workload data under `/home/k8s-data/*` (nuc2) and `/var/lib/k8s-data/*`
+(RK1 nodes) is preserved by default — these host directories back the static
+`local-nvme` PVs and are left untouched unless `-e wipe_local_data=true` is
+passed. NFS backups on the NAS are always preserved (they live outside the
+cluster).
 
 ## Reinstall K3s on a single worker
 
@@ -74,11 +77,15 @@ ansible-playbook pb_all.yml --tags cluster      # Install/update ArgoCD + servic
 
 ## What happens to data during a rebuild?
 
-| Operation | eMMC | NVMe | Longhorn volumes | ArgoCD state |
-|-----------|------|------|-------------------|--------------|
-| Re-flash | Erased | Preserved | Preserved (if on NVMe) | Redeployed from Git |
-| K3s reinstall | Unchanged | Unchanged | Preserved | Redeployed from Git |
-| Cluster redeploy | Unchanged | Unchanged | Preserved | Reinstalled |
+| Operation | eMMC | NVMe | `local-nvme` data dirs | NFS backups on NAS | ArgoCD state |
+|-----------|------|------|-------------------------|--------------------|--------------|
+| Re-flash | Erased | Preserved | Preserved (on host) | Preserved (external) | Redeployed from Git |
+| K3s reinstall | Unchanged | Unchanged | Preserved | Preserved | Redeployed from Git |
+| Cluster redeploy | Unchanged | Unchanged | Preserved | Preserved | Reinstalled |
+
+The `local-nvme` data directories are `/home/k8s-data/*` on nuc2 and
+`/var/lib/k8s-data/*` on RK1 nodes. They are only removed when the
+decommission playbook is run with `-e wipe_local_data=true`.
 
 :::{note}
 eMMC always remains the bootloader for RK1 nodes. The `ubuntu-rockchip-install` tool

--- a/docs/reference/cli-tools.md
+++ b/docs/reference/cli-tools.md
@@ -23,7 +23,7 @@ child app charts.
 ```bash
 helm repo list
 helm list -A
-helm search repo longhorn/longhorn --versions
+helm search repo ingress-nginx/ingress-nginx --versions
 ```
 
 ### kubeseal
@@ -76,16 +76,6 @@ Generates a Headlamp login token and opens a port-forward on port 8443.
 Login Token: <printed>
 URL: https://dashboard.<domain>
  or: https://localhost:8443
-```
-
-### `longhorn.sh`
-
-Prompts you to set a basic-auth password for the Longhorn web UI, then prints the
-access URL.
-
-```text
-Longhorn will be available at:
-  https://longhorn.<domain>
 ```
 
 ## Shell configuration

--- a/docs/reference/production-checklist.md
+++ b/docs/reference/production-checklist.md
@@ -36,7 +36,7 @@ Use this checklist when setting up a new cluster or auditing an existing one.
 
 - [ ] `admin-auth` secret created for Grafana/basic-auth services
 - [ ] oauth2-proxy deployed with GitHub OAuth credentials
-- [ ] OAuth enabled on Grafana, Longhorn, Open WebUI; Headlamp uses Dex OIDC
+- [ ] OAuth enabled on Grafana and Open WebUI; Headlamp and Supabase Studio gated by oauth2-proxy
 - [ ] ArgoCD admin password retrieved and changed from default
 
 ## Resource limits
@@ -47,16 +47,16 @@ Use this checklist when setting up a new cluster or auditing an existing one.
 
 ## Storage
 
-- [ ] Longhorn deployed with 3 replicas per volume
-- [ ] VolumeSnapshotClass deployed
+- [ ] Every static PV in `additions/local-storage/` is `Bound` to its pod
+- [ ] `k8s_data_dirs` role has run on every node (directories exist under `/home/k8s-data/*` on nuc2 and `/var/lib/k8s-data/*` on RK1 nodes)
+- [ ] NAS NFS share is mounted by the `k8s-cluster-nfs` PVC in the `backups` namespace
+- [ ] At least one backup CronJob run has produced a file on the NAS under `/bigdisk/k8s-cluster/backups/`
 - [ ] NFS server configured for LLM model storage (if applicable)
-- [ ] Backup target configured in Longhorn (NFS or S3)
 
 ## Monitoring
 
 - [ ] kube-prometheus-stack deployed (Prometheus + Grafana + Alertmanager)
 - [ ] Grafana accessible and showing dashboards
-- [ ] Longhorn ServiceMonitor enabled
 - [ ] Alert rules reviewed and customised
 
 ## Security
@@ -76,6 +76,6 @@ Use this checklist when setting up a new cluster or auditing an existing one.
 
 ## Backups
 
-- [ ] Longhorn volume snapshots configured (recurring)
+- [ ] CronJob backup targets verified with at least 7 days of retention on NAS
 - [ ] Sealed-secrets key exported and stored securely
 - [ ] Disaster recovery procedure documented and tested

--- a/docs/reference/services.md
+++ b/docs/reference/services.md
@@ -13,8 +13,7 @@ All services deployed by ArgoCD, with their chart sources, versions, and access 
 | Headlamp | `headlamp/headlamp` | 0.41.0 | `headlamp` | `headlamp.<domain>` | OAuth + Token | Kubernetes dashboard |
 | ingress-nginx | `ingress-nginx/ingress-nginx` | 4.15.1 | `ingress-nginx` | — | — | Ingress controller |
 | kernel-settings | Inline DaemonSet | — | `kube-system` | — | — | Sysctl tuning for performance |
-| Longhorn | `longhorn/longhorn` | 1.11.1 | `longhorn` | `longhorn.<domain>` | OAuth | Distributed block storage |
-| oauth2-proxy | `oauth2-proxy/oauth2-proxy` | 10.4.2 | `oauth2-proxy` | `oauth2.<domain>` | GitHub | OAuth proxy for Longhorn, Supabase |
+| oauth2-proxy | `oauth2-proxy/oauth2-proxy` | 10.4.2 | `oauth2-proxy` | `oauth2.<domain>` | GitHub | OAuth proxy for Headlamp and Supabase Studio |
 | RKLlama | Helm chart (local) | 0.0.4 | `rkllama` | `rkllama.<domain>` | None | NPU-accelerated LLM server (Rockchip RK1) |
 | llama.cpp | Helm chart (local) | — | `llamacpp` | `llamacpp.<domain>` | — | CUDA-accelerated LLM server (NVIDIA GPU) |
 | NVIDIA device plugin | `nvidia/nvidia-device-plugin` | 0.19.0 | `nvidia-device-plugin` | — | — | Advertises `nvidia.com/gpu` resources to the scheduler |
@@ -59,16 +58,17 @@ Image pinned to `0.9.2`.
 
 Full monitoring stack: Prometheus for metrics collection, Grafana for dashboards,
 Alertmanager for alerts. Grafana authenticates via Dex (OIDC) with GitHub —
-emails in `admin_emails` get Admin role, those in `viewer_emails` get Viewer. Longhorn persistent
-volumes for data (30Gi Grafana, 40Gi Prometheus). Grafana resource limits:
-100m/256Mi request, 500m/512Mi limit.
+emails in `admin_emails` get Admin role, those in `viewer_emails` get Viewer. Uses
+static `local-nvme` PVs pinned by node affinity (Grafana → node03 30Gi,
+Prometheus → node02 40Gi). Grafana resource limits: 100m/256Mi request,
+500m/512Mi limit.
 
 Uses `ServerSideApply=true` sync option due to large CRDs.
 
 ### Headlamp
 
 Modern Kubernetes dashboard. Protected by the cluster-wide oauth2-proxy
-(admin-only, same as Longhorn and Supabase Studio). After OAuth login,
+(admin-only, same as Supabase Studio). After OAuth login,
 paste a ServiceAccount token generated with
 `kubectl create token headlamp -n headlamp` to access the Kubernetes API.
 The Helm chart creates a ClusterRoleBinding granting `cluster-admin` to
@@ -84,23 +84,13 @@ NGINX ingress controller. Admission webhooks are disabled. Resource limits:
 
 DaemonSet that applies system tuning on all nodes:
 - Sets `rmem_max` and `wmem_max` to 7500000 (network buffers)
-- Blacklists Longhorn iSCSI devices from multipathd
 
 All busybox images pinned to `1.37`.
-
-### Longhorn
-
-Distributed block storage with replication, snapshots, and backup support. Includes a
-`VolumeSnapshotClass` for Kubernetes volume snapshots. Web UI protected with OAuth via
-oauth2-proxy. ServiceMonitor enabled for Prometheus metrics.
-
-**Additional manifests:** `additions/longhorn/`
-- `volume-snapshot-class.yaml` — VolumeSnapshotClass (default, Delete policy)
 
 ### oauth2-proxy
 
 Lightweight OAuth authentication proxy. Redirects unauthenticated users to GitHub
-for login. Protects services without native OIDC support: Longhorn and
+for login. Protects services without native OIDC support: Headlamp and
 Supabase Studio. Integrated with nginx ingress annotations. Resource limits:
 10m/64Mi request, 100m/128Mi limit.
 
@@ -191,8 +181,8 @@ user role. Password login is disabled. Connects to both:
 - **llama.cpp** (OpenAI-compatible API) on an NVIDIA GPU — via `openaiBaseApiUrl`
 
 Models from both backends appear merged in the model dropdown. Stores chat history
-and user accounts in a Longhorn-backed 5Gi volume. Resource limits: 100m/256Mi
-request, 500m/1Gi limit.
+and user accounts on a static `local-nvme` PV pinned to node04 (5Gi). Resource
+limits: 100m/256Mi request, 500m/1Gi limit.
 
 :::{note}
 Either backend is optional. The service works with just RKLLama (RK1 cluster),
@@ -238,7 +228,8 @@ Components: db, auth, rest, realtime, storage, functions, studio, kong, meta,
 minio (10 pods total). All pods scheduled on x86/amd64 nodes.
 
 MinIO provides S3-compatible object storage for file attachments, backed by a
-Longhorn PVC. Studio is protected by OAuth via oauth2-proxy.
+static `local-nvme` PV pinned to nuc2. Studio is protected by OAuth via
+oauth2-proxy.
 
 **Additional manifests:** `additions/supabase/`
 - `templates/supabase-secret.yaml` — SealedSecret for all Supabase credentials (JWT, DB password, API keys, MinIO credentials)

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -134,7 +134,7 @@ kubectl patch app <app-name> -n argo-cd --type json \
 ### Viewer emails can access oauth2-proxy-gated services
 
 **Symptom:** Users with viewer emails can access admin-only services
-(Longhorn, Supabase Studio) — oauth2-proxy returns 202 instead of 403.
+(Headlamp, Supabase Studio) — oauth2-proxy returns 202 instead of 403.
 
 **Cause:** The oauth2-proxy Helm chart generates `email_domains = ["*"]` in
 its default ConfigMap. This acts as an OR with `authenticatedEmailsFile` —
@@ -237,37 +237,27 @@ When testing cluster changes that affect web UIs, use an incognito window first.
 This avoids polluting your browser cache with intermediate states.
 :::
 
-## Longhorn
+## Local-nvme PVs and NFS backups
 
-### Cannot uninstall Longhorn
+### Static PV not bound
 
-**Symptom:** `helm uninstall longhorn` hangs or fails.
+**Symptom:** A pod stuck `Pending` with events like `no persistent volumes
+available for this claim`.
 
-**Cause:** Longhorn requires its uninstall job to detach all volumes and clean up
-node state. Volumes still attached to running pods prevent uninstall.
+**Check:** `kubectl get pv -l type=local-nvme` — every PV listed in
+`additions/local-storage/` should be `Bound`.
 
-**Fix:**
+**Fix:** Verify the data directory exists on the target node
+(`/home/k8s-data/<app>` on nuc2, `/var/lib/k8s-data/<app>` on the RK1
+nodes); re-run `ansible-playbook pb_all.yml --tags cluster` to let the
+`k8s_data_dirs` role recreate any missing directory.
 
-1. Scale down all workloads using Longhorn PVCs
-2. Delete any remaining PVCs manually
-3. Run the Longhorn uninstall procedure:
+### Restoring from an NFS backup
 
-```bash
-kubectl -n longhorn apply -f https://raw.githubusercontent.com/longhorn/longhorn/master/uninstall/uninstall.yaml
-kubectl -n longhorn get job/longhorn-uninstall -w
-# Wait for completion, then
-helm uninstall longhorn -n longhorn
-```
-
-### Volume degraded — replica rebuilding
-
-**Symptom:** Longhorn UI shows a volume as `Degraded` with replicas rebuilding.
-
-**Cause:** A node was restarted or lost network temporarily. Longhorn
-automatically rebuilds under-replicated volumes.
-
-**Action:** No action needed. Monitor progress in the Longhorn UI. Rebuilding
-typically completes within minutes depending on volume size.
+The daily/weekly backup CronJobs in the `backups` namespace write
+compressed dumps to `/bigdisk/k8s-cluster/backups/` on the NAS. To find
+the latest, `ls -lt /bigdisk/k8s-cluster/backups/supabase-db/` on the
+NAS host and pick the newest `*.sql.gz`.
 
 ## Networking
 
@@ -415,8 +405,14 @@ K3s's embedded etcd auto-compacts, but a restart forces immediate compaction.
 GID 106) from changing file ownership. Unlike most Postgres images that use
 UID/GID 999, the Supabase image uses non-standard IDs.
 
-**Fix:** Use Longhorn (or another block storage provider) instead of NFS for
-the Postgres PVC. See {doc}`/explanations/decisions/0006-supabase-nfs-storage`.
+**Fix:** The Supabase database runs on a static `local-nvme` PV pinned to
+nuc2 (backed by `/home/k8s-data/supabase-db`) — plain filesystem ownership
+works correctly. NFS is used only by the backup CronJobs in the `backups`
+namespace to write compressed `pg_dump` output to the NAS; the live
+database never touches NFS. See
+{doc}`/explanations/decisions/0006-supabase-nfs-storage` for the original
+context and {doc}`/explanations/decisions/0012-drop-longhorn` for the
+current architecture.
 
 ### Kong OOMKilled
 
@@ -458,8 +454,9 @@ use `basePath: '/open-brain-mcp'`.
 file access denied, drive may be faulty`.
 
 **Cause:** The Chainguard MinIO image (`cgr.dev/chainguard/minio`) runs as
-UID 65532 (nonroot). Longhorn PVCs are created with root ownership, so MinIO
-cannot write to the volume.
+UID 65532 (nonroot). Static `local-nvme` PVs are backed by hostPath
+directories created with root ownership, so MinIO cannot write to the
+volume.
 
 **Fix:** Add `podSecurityContext.fsGroup: 65532` to the MinIO deployment
 config in `kubernetes-services/templates/supabase.yaml`:

--- a/docs/reference/variables.md
+++ b/docs/reference/variables.md
@@ -63,7 +63,6 @@ Set per-host in `hosts.yml` under the relevant host entry:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `cluster_force` | `false` | Force ArgoCD reinstall |
-| `cluster_longhorn_version` | (version string) | Longhorn chart version (legacy, now in template) |
 
 ## Command-line overrides
 

--- a/docs/tutorials/common-setup.md
+++ b/docs/tutorials/common-setup.md
@@ -130,7 +130,7 @@ idle until configured.
 :::{note}
 `enable_oauth2_proxy` controls whether cluster services require GitHub login.
 Leave it `false` until you have completed the {doc}`/how-to/oauth-setup` guide —
-otherwise services like Grafana and Longhorn will return errors because the
+otherwise services like Grafana will return errors because the
 OAuth proxy is not yet deployed.
 :::
 <!-- end:configure-cluster -->

--- a/docs/tutorials/getting-started-generic.md
+++ b/docs/tutorials/getting-started-generic.md
@@ -128,7 +128,7 @@ ansible-playbook pb_all.yml --tags known_hosts,servers,k3s,cluster
 This runs only the relevant stages:
 
 1. **`known_hosts`** — updates SSH known_hosts for all nodes
-2. **`servers`** — dist-upgrade, installs dependencies (`open-iscsi`, etc.)
+2. **`servers`** — dist-upgrade and installs base dependencies
 3. **`k3s`** — installs K3s control plane and worker nodes
 4. **`cluster`** — installs ArgoCD and deploys all cluster services
 


### PR DESCRIPTION
## Summary

Mechanical 56-edit sweep across 23 files to remove stale Longhorn references
left over from PR #324 (drop-Longhorn cutover). Replaces them with the new
architecture: static `local-nvme` PVs per host with daily/weekly NFS backup
CronJobs to a NAS. Supabase Studio becomes the canonical oauth2-proxy example
throughout `authentication.md`.

Longhorn references remain **only** in:

- `decisions/0009-longhorn-exclude-workstations.md` (superseded historical ADR)
- `decisions/0012-drop-longhorn.md` (the decision itself)
- `decisions/0011-minio-file-attachments.md` (historical body preserved;
  added a top note noting the PVC backing has since migrated per ADR 0012)
- `decisions/0005-ws03-workstation-taint.md` (historical Consequences bullet
  preserved)
- `how-to/alternative-storage.md` (Longhorn documented as an optional alt)
- `reference/troubleshooting.md:414` (crossref link to ADR 0012 slug)
- `decisions.md` (toctree entries referencing ADR filenames)

This is PR A of 6 from the post-PR324 docs review.

## Test plan

- [x] `grep -rn -i longhorn docs/ README.md` returns hits only in the
      allowlisted files above.
- [x] `python -m sphinx -W --keep-going docs docs/_build` succeeds without
      warnings or broken cross-references.
- [x] Spot-checked mermaid diagrams in `authentication.md` — still parse
      after Longhorn removal from `ProxyAuth` subgraph and edges.
- [x] `docs/_static/architecture.html` interactive showcase card replaced
      with a local-nvme + NFS backups description.