### PR TITLE
docs: consolidate ingress architecture into authentication.md

### DIFF
--- a/docs/explanations/authentication.md
+++ b/docs/explanations/authentication.md
@@ -44,6 +44,78 @@ receive admin privileges; everyone else gets a read-only or viewer role.
 A separate `viewer_emails` list identifies users who can authenticate via
 Dex OIDC but receive only read-only access.
 
+## Ingress architecture
+
+Layer 2 authentication is enforced at **ingress-nginx**, the single
+entry point for every request that reaches the cluster. Understanding
+where ingress-nginx sits clarifies *where* Dex and oauth2-proxy plug in
+and *why* the auth-url subrequest pattern works.
+
+```{mermaid}
+flowchart TB
+    subgraph Internet
+        CF[Cloudflare Edge]
+    end
+
+    subgraph LAN["Local Network"]
+        CLIENT[LAN Client]
+    end
+
+    subgraph Cluster["K3s Cluster"]
+        ING[ingress-nginx<br/>LoadBalancer on workers]
+        SVC1[echo service]
+        SVC2[grafana service]
+        SVC3[argocd service]
+        CFPOD[cloudflared pod]
+    end
+
+    CF -->|"tunnel"| CFPOD
+    CFPOD -->|"HTTP"| ING
+    CLIENT -->|"DNS → worker IP"| ING
+    ING --> SVC1 & SVC2 & SVC3
+```
+
+Tunnel-routed requests arrive at the `cloudflared` pod via an outbound
+tunnel and are forwarded over plain HTTP to ingress-nginx. LAN clients
+hit ingress-nginx directly over the worker node IPs. In both cases
+ingress-nginx is where OAuth subrequests are issued — either to the
+cluster-wide oauth2-proxy or, indirectly, to a service that authenticates
+itself against Dex.
+
+### NGINX Ingress (not Traefik)
+
+K3s ships Traefik as its default ingress controller, but this project
+disables it (`--disable=traefik`) and deploys **ingress-nginx** instead.
+Reasons:
+
+- More widely documented in the Kubernetes ecosystem
+- Better support for TLS passthrough (needed for ArgoCD)
+- More straightforward configuration model
+- Mature `auth-url` / `auth-signin` annotation support, which is what
+  oauth2-proxy relies on for the subrequest flow described later in this
+  page
+
+### LoadBalancer on workers
+
+The ingress-nginx controller runs on **worker nodes** — in multi-node
+clusters the control plane carries a `NoSchedule` taint. DNS entries for
+all services must therefore point to worker node IPs, not the control
+plane. For single-node clusters, DNS points to that single node.
+
+For round-robin across workers:
+
+```
+*.example.com  A  192.168.1.82
+*.example.com  A  192.168.1.83
+*.example.com  A  192.168.1.84
+```
+
+A single worker IP also works — kube-proxy routes traffic to the ingress
+pod regardless of which worker receives the connection.
+
+See {doc}`networking` for TLS certificate issuance, Cloudflare tunnel
+details, and ArgoCD's TLS termination pattern.
+
 ## Auth method summary
 
 | Service | Layer 1 (Cloudflare) | Layer 2 (Ingress) | Layer 3 (App RBAC) |

--- a/docs/explanations/networking.md
+++ b/docs/explanations/networking.md
@@ -1,60 +1,10 @@
 # Networking
 
-This page explains the networking architecture: how traffic reaches cluster services,
-TLS certificate issuance, and the Cloudflare tunnel integration.
-
-## Ingress architecture
-
-```mermaid
-flowchart TB
-    subgraph Internet
-        CF[Cloudflare Edge]
-    end
-
-    subgraph LAN["Local Network"]
-        CLIENT[LAN Client]
-    end
-
-    subgraph Cluster["K3s Cluster"]
-        ING[ingress-nginx<br/>LoadBalancer on workers]
-        SVC1[echo service]
-        SVC2[grafana service]
-        SVC3[argocd service]
-        CFPOD[cloudflared pod]
-    end
-
-    CF -->|"tunnel"| CFPOD
-    CFPOD -->|"HTTP"| ING
-    CLIENT -->|"DNS → worker IP"| ING
-    ING --> SVC1 & SVC2 & SVC3
-```
-
-### NGINX Ingress (not Traefik)
-
-K3s ships Traefik as its default ingress controller, but this project disables it
-(`--disable=traefik`) and deploys **ingress-nginx** instead. Reasons:
-
-- More widely documented in the Kubernetes ecosystem
-- Better support for TLS passthrough (needed for ArgoCD)
-- More straightforward configuration model
-
-### LoadBalancer on workers
-
-The ingress-nginx controller runs on **worker nodes** (in multi-node clusters the
-control plane has a `NoSchedule` taint). DNS entries for all services must point to
-worker node IPs, not the control plane. For single-node clusters, DNS points to that
-single node.
-
-For round-robin across workers:
-
-```
-*.example.com  A  192.168.1.82
-*.example.com  A  192.168.1.83
-*.example.com  A  192.168.1.84
-```
-
-A single worker IP also works — kube-proxy routes traffic to the ingress pod
-regardless of which worker receives the connection.
+This page explains cluster routing and TLS: how TLS certificates are issued,
+how the Cloudflare tunnel provides external access, and how ArgoCD terminates
+TLS at the ingress. The ingress-nginx routing architecture itself — which is
+the entry point for Layer 2 authentication — lives in
+{doc}`authentication` under "Ingress architecture".
 
 ## TLS certificates
 


### PR DESCRIPTION
## Summary

- Moves the ingress-nginx routing material (flowchart, Traefik-vs-nginx rationale, LoadBalancer-on-workers detail) from \`docs/explanations/networking.md\` into a new **Ingress architecture** section in \`docs/explanations/authentication.md\`, immediately after the three-layer auth model.
- Rewrites \`networking.md\` to focus exclusively on TLS certificate issuance, the Cloudflare tunnel, and ArgoCD TLS termination. Its intro now cross-references the relocated section.
- Adds one extra bullet to the nginx rationale about \`auth-url\` annotation support — the missing link that makes the ingress content belong on the auth page.

## Why

Layer 2 of the auth model is enforced at ingress-nginx, so the ingress architecture is the natural grounding for the Dex vs oauth2-proxy discussion that follows on the same page. Previously a reader had to flip between two explanations pages to see how the pieces fit together.

## Context

PR **D** of 6 from the post-PR #324 documentation review (§3.2 of \`docs-review-report.md\`). Follows PRs A (#327), B (#328), and C (#329) already merged. Per the review plan, C → D → E → F are running sequentially against \`main\`.

No \`{doc}\` references to either page used explicit anchors, so no cross-reference updates were needed. Supabase Studio (the canonical oauth2-proxy example introduced in PR A) is preserved unchanged — no Longhorn is re-introduced.

## Test plan

- [x] \`python -m sphinx -W --keep-going docs docs/_build\` — clean build, no new warnings
- [x] No Longhorn references in either file
- [ ] Reviewer sanity-check that the ingress content reads naturally in its new home and the remaining \`networking.md\` still has a coherent scope (TLS + tunnel + ArgoCD TLS termination)

🤖 Generated with [Claude Code](https://claude.com/claude-code)