### PR TITLE
docs: findability + cross-linking pass (PR E of 6)

### DIFF
--- a/docs/explanations/ansible-roles.md
+++ b/docs/explanations/ansible-roles.md
@@ -184,9 +184,15 @@ on its target node (guarded by `inventory_hostname`).
 
 Data lives outside `/var/lib/rancher` deliberately: `pb_decommission.yml`
 wipes `/var/lib/rancher` to reset K3s, but these directories are preserved
-so PVC data survives a cluster rebuild. The one-time NFS share setup that
-hosts the backup CronJob output is a separate manual runbook — see
-`docs/how-to/nas-setup.md`.
+**by default** so PVC data survives a cluster rebuild. To wipe them as
+part of decommissioning, opt in with the destructive flag:
+
+```bash
+ansible-playbook pb_decommission.yml -e wipe_local_data=true
+```
+
+The one-time NFS share setup that hosts the backup CronJob output is a
+separate manual runbook — see {doc}`../how-to/nas-setup`.
 
 ---
 

--- a/docs/explanations/kubernetes-services.md
+++ b/docs/explanations/kubernetes-services.md
@@ -145,7 +145,10 @@ Two special services implement the cluster's stateful-data strategy:
   On-disk backing lives at `/home/k8s-data/*` (nuc2) and
   `/var/lib/k8s-data/*` (RK1 nodes) — directories created idempotently
   by the `k8s_data_dirs` Ansible role and **preserved by default** on
-  decommission (see {doc}`../how-to/backup-restore`).
+  decommission. For the authoritative per-workload directory → node →
+  owner mapping, and the opt-in `-e wipe_local_data=true` flag that
+  removes them, see the `k8s_data_dirs` section of
+  {doc}`ansible-roles`.
 
 - **`backups`** (`templates/backups.yaml`, `additions/backups/`) — one
   namespace, one static NFS `PersistentVolume` pointing at

--- a/docs/how-to/bootstrap-cluster.md
+++ b/docs/how-to/bootstrap-cluster.md
@@ -3,6 +3,14 @@
 After the Ansible playbook completes, ArgoCD is installed and will begin syncing
 all services. Follow these steps to finish the setup.
 
+:::{tip}
+**NAS prerequisite for backups.** The daily and weekly backup CronJobs write
+to an NFS export on a NAS. If you intend to run backups (recommended for any
+stateful workload — Supabase, Grafana, Prometheus, Open WebUI), set up the
+NAS share **before** the first backup runs. See {doc}`nas-setup` — this is a
+one-time manual runbook on the NAS itself.
+:::
+
 ## Set Up the Shared Admin Password
 
 Several services share a common admin password via a Kubernetes secret called
@@ -83,6 +91,14 @@ certificates, and optionally exposes services to the internet.
 
 Other guides:
 
+- {doc}`../reference/services` — pick which services your cluster should run
+  (quick-start configurations: LLM-only, AI memory, monitoring, full stack)
 - {doc}`manage-sealed-secrets` — manage encrypted secrets in the repository
 - {doc}`add-remove-services` — customise which services are deployed
+- {doc}`nas-setup` — create the NFS share layout used by backup CronJobs
+  (one-time manual runbook on the NAS)
+- {doc}`backup-restore` — verify backup CronJobs and restore from a dump
+- {doc}`alternative-storage` — swap the static `local-nvme` default for
+  another CSI driver (Longhorn, Rook-Ceph, …)
 - {doc}`rkllama-models` — pull LLM models for RKLLama (RK1 clusters only)
+- {doc}`llamacpp-models` — pull GGUF models for llama.cpp (NVIDIA GPU nodes)

--- a/docs/how-to/cloudflare-ssh-tunnel.md
+++ b/docs/how-to/cloudflare-ssh-tunnel.md
@@ -1,5 +1,15 @@
 # Set Up a Cloudflare SSH Tunnel for Remote Cluster Access
 
+:::{note}
+**When to use this guide.** Use this guide when you want to reach the
+cluster's control-plane shell / `kubectl` from outside your LAN without
+opening any inbound firewall ports. It adds an Access-gated SSH route on
+top of the existing Cloudflare tunnel. **Prerequisite:** complete
+{doc}`cloudflare-tunnel` first so that `cloudflared` is running in the
+cluster. For exposing *web* services through the tunnel (Grafana,
+Headlamp, Open WebUI, ArgoCD), see {doc}`cloudflare-web-tunnel` instead.
+:::
+
 This guide walks through setting up secure remote access to your K3s cluster via an
 SSH tunnel through Cloudflare Zero Trust, without opening any inbound firewall ports.
 

--- a/docs/how-to/cloudflare-tunnel.md
+++ b/docs/how-to/cloudflare-tunnel.md
@@ -1,5 +1,19 @@
 # Set Up DNS, TLS & Cloudflare Tunnel
 
+:::{note}
+**When to use this guide.** This is the **base** Cloudflare setup — start
+here. It covers the Cloudflare-managed domain, DNS-01 TLS certificates,
+and an optional tunnel for a single echo service. For the specialised
+follow-ups, see the other two Cloudflare how-tos once this one works:
+
+- {doc}`cloudflare-web-tunnel` — expose a set of OAuth-protected web
+  services (Grafana, Headlamp, Open WebUI, ArgoCD) through the tunnel
+  with a single `enable_cloudflare_tunnel` toggle.
+- {doc}`cloudflare-ssh-tunnel` — add a Cloudflare Access-gated SSH
+  tunnel for remote `kubectl` / shell access without opening inbound
+  firewall ports.
+:::
+
 This guide sets up three things:
 
 1. **A Cloudflare-managed domain** — required for DNS and TLS certificates
@@ -186,7 +200,10 @@ on your LAN. If you don't need public internet access, you can stop here.
 
 Follow this section only if you want to expose selected services to the
 internet. If LAN-only access is sufficient, skip to {doc}`oauth-setup` or
-the other guides listed in {doc}`bootstrap-cluster`.
+the other guides listed in {doc}`bootstrap-cluster`. For remote shell /
+`kubectl` access (rather than web exposure), use
+{doc}`cloudflare-ssh-tunnel` instead — it adds an Access-gated SSH route
+on top of the same tunnel.
 
 ### 4.1 Create a tunnel
 

--- a/docs/how-to/cloudflare-web-tunnel.md
+++ b/docs/how-to/cloudflare-web-tunnel.md
@@ -1,5 +1,16 @@
 # Expose Web Services via Cloudflare Tunnel
 
+:::{note}
+**When to use this guide.** Use this guide when you want a single toggle
+(`enable_cloudflare_tunnel: true`) to publish all OAuth-protected web
+services — Grafana, Headlamp, Open WebUI, oauth2-proxy, and ArgoCD —
+through your Cloudflare tunnel at once, gated by Cloudflare Access.
+**Prerequisites:** complete {doc}`cloudflare-tunnel` first (for the base
+tunnel and DNS/TLS setup) and {doc}`oauth-setup` (for the in-cluster
+OAuth layer). If you only need remote shell access, use
+{doc}`cloudflare-ssh-tunnel` instead.
+:::
+
 This guide extends the base Cloudflare Tunnel setup to make cluster web services
 accessible from the internet through Cloudflare Zero Trust. No inbound firewall
 ports are opened — all traffic flows through `cloudflared`'s outbound connection.

--- a/docs/how-to/open-brain.md
+++ b/docs/how-to/open-brain.md
@@ -39,10 +39,11 @@ enable_open_brain_mcp: true
 
 :::{tip}
 The NFS export is used by the daily/weekly backup CronJobs in the `backups`
-namespace — they dump `supabase-db` to NAS as compressed SQL files. The
-live Supabase PostgreSQL database, Storage and MinIO all run on static
-`local-nvme` PVs pinned to nuc2, which is more reliable for database
-workloads than networked storage.
+namespace — they dump `supabase-db` to NAS as compressed SQL files. See
+{doc}`backup-restore` for how the CronJobs are scheduled and how to restore
+from a dump. The live Supabase PostgreSQL database, Storage and MinIO all
+run on static `local-nvme` PVs pinned to nuc2, which is more reliable for
+database workloads than networked storage.
 :::
 
 ## 2 -- Generate and seal credentials

--- a/docs/tutorials/ai-guided-setup.md
+++ b/docs/tutorials/ai-guided-setup.md
@@ -58,10 +58,13 @@ network speed.
 After the command completes, your cluster is running with all core services
 managed by ArgoCD. Claude will print next steps, but here is a summary:
 
+- **Pick which services to run** — see {doc}`/reference/services` for the
+  quick-start configurations (LLM-only, AI memory, monitoring, full stack)
 - **Access services now** via port-forward — see {doc}`/how-to/accessing-services`
 - **Expose services to the internet** — follow {doc}`/how-to/cloudflare-tunnel`
 - **Add GitHub OAuth** — follow {doc}`/how-to/oauth-setup`
 - **Enable AI memory** — follow {doc}`/how-to/open-brain`
+- **Set up the NAS share for backups** — follow {doc}`/how-to/nas-setup`
 
 ## Prefer a manual setup?
 


### PR DESCRIPTION
## Summary

PR E of 6 from the post-PR324 docs review (see `docs-review-report.md` at
repo root). Strengthens navigation between tutorials, how-tos, and
reference pages that had become isolated after the post-PR324 structural
rework, and consolidates the local-storage narrative around the single
authoritative table in `ansible-roles.md`.

- **`bootstrap-cluster.md`** — surfaces the NAS-for-backups prerequisite
  up-front and expands **Next Steps** with the new services decision
  tool, `nas-setup`, `backup-restore`, `alternative-storage`, and
  `llamacpp-models`.
- **`ai-guided-setup.md`** — `/bootstrap-cluster` next-steps now point at
  `services.md` (pick which services) and `nas-setup` (backup prereq).
- **`open-brain.md`** — links `backup-restore` where the CronJobs are
  first introduced.
- **Three Cloudflare how-tos** — each gets a "When to use this" callout
  at the top so forkers can pick the right one; strengthens the
  `cloudflare-tunnel` Part 4 intro with a pointer to
  `cloudflare-ssh-tunnel`.
- **`ansible-roles.md` (`k8s_data_dirs`)** — documents the opt-in
  `-e wipe_local_data=true` flag alongside the preservation behaviour.
- **`kubernetes-services.md`** — forward-references the authoritative
  `k8s_data_dirs` section in `ansible-roles.md` for the per-workload
  directory → node → owner mapping.

PR order: ~~A~~ → ~~B~~ → ~~C~~ → ~~D~~ → **E (this)** → F.

## Test plan

- [x] `python -m sphinx -W --keep-going docs docs/_build` builds clean
- [x] Review rendered cross-references for the touched pages
- [ ] Merge after review

🤖 Generated with [Claude Code](https://claude.com/claude-code)