### PR TITLE
docs: tutorials + README tightening (PR F of 6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,25 @@ All cluster customisation lives in just **two files**
 so you can fork the repo, edit those files, and have your own cluster running
 in minutes.
 
+## Architecture at a glance
+
+The cluster is GitOps-first: Ansible bootstraps K3s and ArgoCD, then
+ArgoCD syncs everything else from `kubernetes-services/` in this repo.
+Stateful data lives on **static `local-nvme` PVs** — one per workload,
+pinned to a specific node — with **daily and weekly CronJob backups to
+NFS** on a NAS. This keeps operations simple (no replicated CSI driver)
+while still surviving cluster rebuilds and giving off-cluster
+point-in-time restore. See the
+[**Interactive Architecture Showcase**](https://gilesknap.github.io/tpi-k3s-ansible/architecture.html)
+for a visual tour, the [architecture explanation](https://gilesknap.github.io/tpi-k3s-ansible/explanations/architecture.html)
+for the layered model, and the
+[services reference](https://gilesknap.github.io/tpi-k3s-ansible/reference/services.html)
+for quick-start configurations (LLM-only, AI memory, monitoring, full
+stack) to help you pick which services to run.
+
 Source          | <https://github.com/gilesknap/tpi-k3s-ansible>
 :---:           | :---:
 Documentation   | <https://gilesknap.github.io/tpi-k3s-ansible>
-**Architecture**    | [**Interactive Architecture Showcase**](https://gilesknap.github.io/tpi-k3s-ansible/architecture.html) — visual guide to every layer of the cluster
 
 ## Features
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,9 @@ extensions = [
 # MyST extensions
 myst_enable_extensions = ["colon_fence"]
 myst_fence_as_directive = ["mermaid"]
+# Auto-generate anchors for headings up to level 3 so in-page links like
+# `[ArgoCD](#argocd)` resolve without explicit `(label)=` markers.
+myst_heading_anchors = 3
 
 # Mermaid rendering
 mermaid_output_format = "raw"

--- a/docs/how-to/accessing-services.md
+++ b/docs/how-to/accessing-services.md
@@ -9,6 +9,18 @@ configured first — see {doc}`cloudflare-tunnel` Parts 1–3. **Port-forward**
 commands work immediately after bootstrap with no additional setup.
 :::
 
+## I want to…
+
+| Task | Jump to |
+|---|---|
+| Watch ArgoCD sync status | [ArgoCD](#argocd) |
+| Review ArgoCD app health history | [argocd-monitor](#argocd-monitor) |
+| View cluster metrics and dashboards | [Grafana](#grafana) |
+| Inspect pods, logs, and Kubernetes objects in a UI | [Headlamp (Kubernetes Dashboard)](#headlamp-kubernetes-dashboard) |
+| Chat with a local LLM | [Open WebUI (LLM Chat)](#open-webui-llm-chat) |
+| Run SQL or browse the Open Brain database | [Supabase Studio (Open Brain)](#supabase-studio-open-brain) |
+| Verify ingress, TLS and request headers end-to-end | [Echo Test Service](#echo-test-service) |
+
 ## ArgoCD
 
 Via ingress: **https://argocd.\<domain\>**

--- a/docs/how-to/nas-setup.md
+++ b/docs/how-to/nas-setup.md
@@ -16,13 +16,14 @@ hand-editing `/etc/exports` is dangerous because the UI overwrites it.
 
 The good news is we don't need a new export at all. Your QNAP already
 exports `/share/CACHEDEV1_DATA/bigdisk` with read-write access to the
-cluster subnet (`192.168.1.1/24`, which equals `192.168.1.0/24`). It is
-already mounted by rkllama, llamacpp, and the supabase db-dump PV using
-the client-visible NFSv4-pseudo-filesystem path `/bigdisk/...`.
+cluster subnet, and it is already mounted by rkllama, llamacpp, and
+the supabase db-dump PV.
 
 So this runbook **just creates a new subdirectory inside the existing
 `bigdisk` export** — `bigdisk/k8s-cluster/` — and populates it. No
-export changes, no `/etc/exports` edits, no QNAP UI configuration.
+export changes, no `/etc/exports` edits, no QNAP UI configuration. The
+exact client-side vs server-side path mapping is covered under
+[Two paths, same directory](#two-paths-same-directory) below.
 
 ## What we're creating
 

--- a/docs/how-to/oauth-setup.md
+++ b/docs/how-to/oauth-setup.md
@@ -6,28 +6,12 @@ see {doc}`/explanations/authentication`.
 :::
 
 This guide walks through configuring both authentication paths used by the
-cluster:
+cluster. Each path uses its own GitHub OAuth App:
 
-- **Part A** — Dex OIDC (ArgoCD, Grafana, Open WebUI, argocd-monitor)
-- **Part B** — oauth2-proxy (Supabase Studio, Headlamp — admin-only)
-
-```{mermaid}
-flowchart LR
-    GH[GitHub]
-    DEX[Dex inside ArgoCD]
-    OAP[oauth2-proxy]
-
-    GH -->|OAuth App 1| DEX
-    GH -->|OAuth App 2| OAP
-
-    DEX --> ArgoCD
-    DEX --> Grafana
-    DEX --> Open-WebUI
-    DEX --> argocd-monitor
-
-    OAP --> Supabase
-    OAP --> Headlamp
-```
+- **Part A** — Dex OIDC, used by **ArgoCD, Grafana, Open WebUI, and
+  argocd-monitor** (services with native OIDC support).
+- **Part B** — oauth2-proxy, used by **Supabase Studio and Headlamp**
+  (admin-only services with no native OIDC).
 
 ## Prerequisites
 

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -2,6 +2,44 @@
 
 Step-by-step guides that walk you through setting up a K3s cluster from scratch.
 
+## Why the cluster is built this way
+
+Before you start installing, two design choices shape everything the
+tutorials ask you to do. Neither is the only way to run K3s at home —
+they are the choices this repo made, and knowing *why* will save you
+from fighting the defaults later.
+
+**Static local-nvme PVs, one per stateful workload.** Each stateful
+service (Supabase DB, Grafana, Prometheus, Open WebUI, …) gets a
+hand-declared `PersistentVolume` backed by a plain directory on a
+specific node — e.g. `/home/k8s-data/supabase-db` on `nuc2`. The PV
+is pre-bound to its PVC via `claimRef` and pinned to its node via
+`nodeAffinity`, so the pod *must* land there and the data *must*
+survive a rebuild. No CSI driver, no replicas, no block-storage
+cluster. The trade-off is explicit: you accept that losing a
+worker's disk loses that workload until the disk is restored, in
+exchange for far simpler operations, lower RAM/CPU overhead on small
+nodes, and data that transparently survives
+`ansible-playbook pb_all.yml`. The full rationale is in
+{doc}`explanations/decisions/0012-drop-longhorn`.
+
+**Backups live on NFS, not in the cluster.** Point-in-time backups of
+every stateful service are written by `CronJob`s to a single NFS tree
+on a NAS. That NAS is set up **once, by hand**, via
+{doc}`how-to/nas-setup` — Ansible has no access to it, by design,
+because the NAS hosts mixed personal data. So the stateful-data
+strategy has two halves: local PVs give you rebuild survival, and
+NFS CronJobs give you off-cluster point-in-time restore.
+
+**Pod-to-node pinning is deliberate.** Because each stateful PV is
+tied to one node, the corresponding Deployment/StatefulSet must also
+land on that node. The existing pinning — `prometheus→node02`,
+`grafana→node03`, `open-webui→node04`, Supabase trio `→nuc2` — is
+not an accident, and new RWO `local-nvme` workloads need to pick
+their own host. This is called out in `CLAUDE.md` as a hard rule.
+
+With that mental model in place, pick your install path:
+
 ```{toctree}
 :maxdepth: 1
 

--- a/docs/tutorials/common-setup.md
+++ b/docs/tutorials/common-setup.md
@@ -127,6 +127,15 @@ llamacpp), you can leave the NFS settings as-is. The services will deploy but re
 idle until configured.
 :::
 
+:::{important}
+**NFS is also a prerequisite for backups.** The daily and weekly backup
+CronJobs write stateful-service dumps (Supabase DB, Grafana, Open WebUI,
+…) to a shared NFS tree on a NAS. If you plan to run backups — strongly
+recommended for any stateful workload — set up the NAS share before the
+first backup fires using {doc}`/how-to/nas-setup`. This is a one-time
+manual runbook on the NAS itself (Ansible has no access to it by design).
+:::
+
 :::{note}
 `enable_oauth2_proxy` controls whether cluster services require GitHub login.
 Leave it `false` until you have completed the {doc}`/how-to/oauth-setup` guide —


### PR DESCRIPTION
## Summary

Final PR in the post-PR324 docs review (see \`docs-review-report.md\` at
repo root). Closes out the §3.6 tightening wins, the Topic 4
*"understand why"* coverage gap in \`tutorials.md\`, and the README
architecture paragraph.

- **\`tutorials.md\`** — new **"Why the cluster is built this way"**
  section (three paragraphs on local-nvme PVs, NFS backup philosophy,
  and deliberate pod-to-node pinning) before the toctree, so forkers
  get the mental model before they start installing.
- **\`README.md\`** — new **"Architecture at a glance"** paragraph
  linking to the interactive showcase, the architecture explanation,
  and the services decision tool from PR C. The showcase link moves
  into the paragraph so it reads naturally instead of sitting in the
  metadata table.
- **\`common-setup.md\`** — NFS-for-backups callout added alongside the
  existing NFS-for-LLMs note, pointing at \`nas-setup.md\`.
- **\`accessing-services.md\`** — task-oriented **"I want to…"**
  navigation table at the top so users can jump straight to the
  service that does what they want.
- **\`oauth-setup.md\`** — dropped the top Mermaid diagram (duplicated
  the Part A / Part B summary immediately following). The bullet list
  is expanded slightly so nothing is lost.
- **\`nas-setup.md\`** — trimmed the NFSv4-pseudo-filesystem explanation
  out of the "Why this doesn't create a new NFS export" section and
  linked forward to "Two paths, same directory" which covers it in
  detail.
- **\`conf.py\`** — enabled \`myst_heading_anchors = 3\` so in-page links
  like \`[ArgoCD](#argocd)\` resolve automatically (needed by the new
  accessing-services nav table).

PR order: ~~A~~ → ~~B~~ → ~~C~~ → ~~D~~ → ~~E~~ → **F (this, last)**.

## After this lands

Per \`project_docs_review_2026_04.md\`:

1. Run \`grep -rn -i longhorn docs/ README.md\` — hits must only appear
   in the allowlisted files (ADR 0009/0012, alternative-storage.md).
2. Delete \`docs-review-report.md\` from repo root (review artifact).
3. Delete the \`project_docs_review_2026_04.md\` memory entry and clean
   up \`MEMORY.md\`.

## Test plan

- [x] \`python -m sphinx -W --keep-going docs docs/_build\` builds clean
- [x] Reviewed tutorial "why" section for accuracy against CLAUDE.md
      and the drop-Longhorn ADR (0012)
- [ ] Merge after review

🤖 Generated with [Claude Code](https://claude.com/claude-code)