### PR TITLE
config: add cf_access_team to values.yaml

### DIFF
--- a/.claude/commands/test-oauth-flow.md
+++ b/.claude/commands/test-oauth-flow.md
@@ -141,7 +141,7 @@ For each service:
   JS is useless against them. A stale `CF_AppSession` from a prior
   cluster session will make CF Access return **503 in the browser** even
   though the cluster-side path is healthy. To flush it, navigate to
-  `https://<access-team>.cloudflareaccess.com/cdn-cgi/access/logout`
+  `https://<cf_access_team from values.yaml>.cloudflareaccess.com/cdn-cgi/access/logout`
   before retrying. Note: the `clusterapps` Access policy requires
   interactive email-OTP sign-in with no SSO fallback — meaning after a
   logout, Supabase cannot be fully browser-tested automatically. Stop

--- a/kubernetes-services/values.yaml
+++ b/kubernetes-services/values.yaml
@@ -38,6 +38,10 @@ enable_oauth2_proxy: true
 # When true, disables ssl-redirect on tunnelled services so Cloudflare's
 # edge TLS termination works without redirect loops.
 enable_cloudflare_tunnel: true
+# Cloudflare Zero Trust team name (the subdomain in
+# <team>.cloudflareaccess.com). Used by the test-oauth-flow skill to
+# build the CF Access logout URL.
+cf_access_team: gilesk
 # Admin email addresses — full access to all services.
 # These emails get: ArgoCD admin, Grafana Admin, Open WebUI admin,
 # oauth2-proxy access (Longhorn, Supabase Studio).


### PR DESCRIPTION
## Summary
- Add `cf_access_team` setting to `values.yaml` alongside the existing Cloudflare Tunnel config
- Update the `test-oauth-flow` skill to reference the values.yaml key instead of a bare `<access-team>` placeholder
- Forkers configure their CF Zero Trust team name once; the skill stays generic

## Test plan
- [ ] Verify `cf_access_team` appears in `values.yaml` with correct comment
- [ ] Verify the skill's logout URL references the new key

🤖 Generated with [Claude Code](https://claude.com/claude-code)