### PR TITLE
fix: use k8s_scale for decommission scale-down

### DIFF
--- a/pb_decommission.yml
+++ b/pb_decommission.yml
@@ -78,15 +78,12 @@
   gather_facts: false
   tasks:
     - name: Scale down monitoring workloads
-      kubernetes.core.k8s:
+      kubernetes.core.k8s_scale:
         api_version: apps/v1
         kind: "{{ item.kind }}"
         name: "{{ item.name }}"
         namespace: monitoring
-        state: present
-        resource_definition:
-          spec:
-            replicas: 0
+        replicas: 0
       loop:
         - { kind: Deployment, name: grafana-prometheus-kube-pr-operator }
         - { kind: StatefulSet, name: alertmanager-grafana-prometheus-kube-pr-alertmanager }
@@ -95,27 +92,21 @@
       ignore_errors: true  # noqa ignore-errors
 
     - name: Scale down open-webui
-      kubernetes.core.k8s:
+      kubernetes.core.k8s_scale:
         api_version: apps/v1
         kind: StatefulSet
         name: open-webui
         namespace: open-webui
-        state: present
-        resource_definition:
-          spec:
-            replicas: 0
+        replicas: 0
       ignore_errors: true  # noqa ignore-errors
 
     - name: Scale down supabase workloads
-      kubernetes.core.k8s:
+      kubernetes.core.k8s_scale:
         api_version: apps/v1
         kind: "{{ item.kind }}"
         name: "{{ item.name }}"
         namespace: supabase
-        state: present
-        resource_definition:
-          spec:
-            replicas: 0
+        replicas: 0
       loop:
         - { kind: Deployment, name: supabase-supabase-auth }
         - { kind: Deployment, name: supabase-supabase-functions }


### PR DESCRIPTION
## Summary
- Switch all three scale-down tasks in `pb_decommission.yml` from `kubernetes.core.k8s` to `kubernetes.core.k8s_scale`
- `k8s` with `state: present` and a partial `resource_definition` triggers a strategic merge patch that fails on immutable selectors in Helm-managed resources — the selector validation errors seen on every decommission run
- `k8s_scale` only sets replicas, avoiding selector validation entirely
- `ignore_errors: true` retained as a safety net for partially torn-down clusters

## Test plan
- [ ] Run `pb_decommission.yml` and verify no selector validation errors on monitoring/open-webui/supabase scale-down tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)