### PR TITLE
docs: remove stale viewer_emails references

### DIFF
--- a/docs/explanations/authentication.md
+++ b/docs/explanations/authentication.md
@@ -40,9 +40,9 @@ GitHub directly).
 
 **Layer 3 — App RBAC** maps the authenticated identity to a role inside
 the application. Emails in the `admin_emails` list in `values.yaml`
-receive admin privileges; everyone else gets a read-only or viewer role.
-A separate `viewer_emails` list identifies users who can authenticate via
-Dex OIDC but receive only read-only access.
+receive admin privileges; all other authenticated users get a read-only
+or viewer role. Entry is gated by Cloudflare Access (email-based OTP),
+so there is no separate viewer list in the repo.
 
 ## Ingress architecture
 
@@ -374,17 +374,20 @@ Cloudflare Access (email allowlist) before reaching the cluster.
 
 ## Managing access
 
-Access is controlled by two email lists in `kubernetes-services/values.yaml`:
+Access is controlled at two layers:
+
+- **Cloudflare Access** — email-based OTP gate managed in the Cloudflare
+  Zero Trust dashboard. This decides who can reach the cluster at all.
+- **`admin_emails`** in `kubernetes-services/values.yaml` — grants admin
+  privileges. Everyone else who passes Cloudflare Access and authenticates
+  via Dex/GitHub gets a viewer/read-only role by default.
 
 ```yaml
 admin_emails:
   - alice@example.com     # full admin access everywhere
-
-viewer_emails:
-  - carol@example.com     # read-only access to Dex-authenticated services
 ```
 
-**Admin emails** are consumed in six places:
+**Admin emails** are consumed in four places:
 
 | Template / Config | Effect |
 |-------------------|--------|
@@ -392,11 +395,10 @@ viewer_emails:
 | `grafana.yaml` | `role_attribute_path` — admin emails get `Admin`, others get `Viewer` |
 | `open-webui.yaml` | `OAUTH_ADMIN_EMAIL` — admin emails get admin role |
 | `argocd-rbac-cm.yml` | `g, <email>, role:admin` — admin emails get ArgoCD admin |
-| Cloudflare Access (manual) | Access policy should include both lists |
 
-**Viewer emails** authenticate via Dex OIDC and receive read-only roles:
-ArgoCD `role:readonly`, Grafana `Viewer`, Open WebUI `user`. They
-cannot access oauth2-proxy-gated services (Headlamp, Supabase Studio).
+All other authenticated users receive read-only roles: ArgoCD
+`role:readonly`, Grafana `Viewer`, Open WebUI `user`. They cannot
+access oauth2-proxy-gated services (Headlamp, Supabase Studio).
 
 :::{important}
 `admin_emails` must be kept in sync in two places:

--- a/docs/explanations/kubernetes-services.md
+++ b/docs/explanations/kubernetes-services.md
@@ -9,7 +9,7 @@ within it becomes an independent ArgoCD Application.
 ```
 kubernetes-services/
 ├── Chart.yaml              # Minimal Helm chart metadata
-├── values.yaml             # Shared values (repo_branch, admin_emails, viewer_emails, etc.)
+├── values.yaml             # Shared values (repo_branch, admin_emails, etc.)
 ├── templates/              # One ArgoCD Application per service
 │   ├── backups.yaml
 │   ├── cert-manager.yaml

--- a/docs/explanations/security.md
+++ b/docs/explanations/security.md
@@ -61,10 +61,9 @@ Current SealedSecrets:
 ### Admin access
 
 Admin email addresses are configured in `admin_emails` in
-`kubernetes-services/values.yaml`. Viewer access is controlled by
-`viewer_emails`. These lists drive role assignment across Grafana,
-Open WebUI, and the oauth2-proxy email allowlist. See
-{doc}`authentication` for details.
+`kubernetes-services/values.yaml`. All other authenticated users
+(those who pass Cloudflare Access and Dex login) receive viewer/
+read-only roles by default. See {doc}`authentication` for details.
 
 ## Devcontainer credential isolation
 

--- a/docs/how-to/cloudflare-web-tunnel.md
+++ b/docs/how-to/cloudflare-web-tunnel.md
@@ -198,7 +198,7 @@ create separate applications for each subdomain. The SSH application from
 |---|---|
 | Policy name | `Allowed Users` |
 | Action | `Allow` |
-| Include rule | Emails — add the same addresses as your `admin_emails` and `viewer_emails` lists |
+| Include rule | Emails — add addresses for everyone who should have access (admins and viewers) |
 
 4. Click **Save application**.
 

--- a/docs/how-to/oauth-setup.md
+++ b/docs/how-to/oauth-setup.md
@@ -102,10 +102,6 @@ Edit `kubernetes-services/values.yaml` and set the email lists:
 # Full admin access to all services
 admin_emails:
   - alice@example.com
-
-# Read-only access to Dex-authenticated services
-viewer_emails:
-  - carol@example.com
 ```
 
 Also add `admin_emails` to `group_vars/all.yml` (required for
@@ -240,7 +236,7 @@ Services protected by oauth2-proxy (admin-only):
 For services exposed via the Cloudflare tunnel, add a second
 authentication layer using Cloudflare Access at zero cluster overhead.
 Configure an Access Application in the Cloudflare Zero Trust dashboard
-with an email allowlist matching both `admin_emails` and `viewer_emails`. See
+with an email allowlist covering everyone who should have access. See
 {doc}`cloudflare-ssh-tunnel` for how Access Applications work.
 
 ## Troubleshooting

--- a/docs/reference/services.md
+++ b/docs/reference/services.md
@@ -176,7 +176,7 @@ Image pinned to `0.9.2`.
 
 Full monitoring stack: Prometheus for metrics collection, Grafana for dashboards,
 Alertmanager for alerts. Grafana authenticates via Dex (OIDC) with GitHub —
-emails in `admin_emails` get Admin role, those in `viewer_emails` get Viewer. Uses
+emails in `admin_emails` get Admin role, all other authenticated users get Viewer. Uses
 static `local-nvme` PVs pinned by node affinity (Grafana → node03 30Gi,
 Prometheus → node02 40Gi). Grafana resource limits: 100m/256Mi request,
 500m/512Mi limit.
@@ -292,8 +292,8 @@ default and survives k3s-agent restarts.
 ### Open WebUI
 
 ChatGPT-style web interface for interacting with LLMs. Authenticates via Dex
-(OIDC) with GitHub — emails in `admin_emails` get admin role, those in `viewer_emails` get
-user role. Password login is disabled. Connects to both:
+(OIDC) with GitHub — emails in `admin_emails` get admin role, all other authenticated
+users get user role. Password login is disabled. Connects to both:
 
 - **RKLLama** (Ollama-compatible API) on the RK1 NPU — via `ollamaUrls`
 - **llama.cpp** (OpenAI-compatible API) on an NVIDIA GPU — via `openaiBaseApiUrl`

--- a/docs/reference/variables.md
+++ b/docs/reference/variables.md
@@ -85,7 +85,6 @@ ansible-playbook pb_all.yml \
 | `enable_oauth2_proxy` | `false` | Enable OAuth2 proxy authentication on protected services. Set `true` after completing OAuth setup ({doc}`/how-to/oauth-setup`). |
 | `enable_cloudflare_tunnel` | `false` | Disable SSL redirect on tunnelled services for Cloudflare Tunnel compatibility. Set `true` after adding public hostnames ({doc}`/how-to/cloudflare-web-tunnel`). |
 | `admin_emails` | *(list of emails)* | GitHub-linked email addresses with full admin access to all OAuth-protected services |
-| `viewer_emails` | *(list of emails)* | GitHub-linked email addresses with read-only access to Dex-authenticated services |
 | `rkllama.nfs.server` | *(your NFS server IP)* | NFS server for RKLLama model storage |
 | `rkllama.nfs.path` | *(your NFS export path)* | Exported NFS path for RKLLama models (`.rkllm` files) |
 | `llamacpp.nfs.server` | *(your NFS server IP)* | NFS server for llama.cpp model storage |

--- a/security-review.md
+++ b/security-review.md
@@ -7,11 +7,12 @@
 
 The project demonstrates strong fundamentals — zero hardcoded secrets,
 SealedSecrets throughout, pre-commit gitleaks enforcement, and proper OIDC
-integration. A two-tier access model (`admin_emails` / `viewer_emails`) has
-been implemented, giving admin users full access and viewer users read-only
-roles across Dex-authenticated services. Services without app-level RBAC
-(Headlamp, Longhorn, Supabase Studio) are restricted to admin-only via
-oauth2-proxy.
+integration. Admin users (listed in `admin_emails`) get full access;
+all other authenticated users get read-only roles. Entry is gated by
+Cloudflare Access (email OTP). Services without app-level RBAC
+(Headlamp, Supabase Studio) are restricted to admin-only via
+oauth2-proxy. *(Note: `viewer_emails` was removed 2026-04-11 —
+viewer access is now implicit for any authenticated non-admin.)*
 
 Remaining issues centre on missing network segmentation, mutable container
 image tags, and OAuth configuration gaps.
@@ -25,7 +26,7 @@ image tags, and OAuth configuration gaps.
 
 | Fix | Commit | Details |
 |-----|--------|---------|
-| Split `oauth2_emails` into `admin_emails` + `viewer_emails` | `6ede8e9` | Two-tier access: admins get full access everywhere, viewers get read-only on Dex-authenticated services (ArgoCD, Grafana, Open WebUI). oauth2-proxy restricted to admin emails only. |
+| Split `oauth2_emails` into `admin_emails` + `viewer_emails` | `6ede8e9` | Two-tier access: admins get full access everywhere, viewers get read-only on Dex-authenticated services (ArgoCD, Grafana, Open WebUI). oauth2-proxy restricted to admin emails only. *(Note: `viewer_emails` later removed 2026-04-11 — viewer role is now the default for any authenticated non-admin; entry gated by Cloudflare Access.)* |
 | Template ArgoCD RBAC from `admin_emails` variable | `6ede8e9` | `argocd-rbac-cm.yml` now iterates `admin_emails` from `group_vars/all.yml` instead of hardcoding a single email. All admin emails get `role:admin`; everyone else defaults to `role:readonly`. |
 | Headlamp access restricted to admin-only | `44c44ec` | Headlamp stays behind oauth2-proxy (now restricted to `admin_emails`), giving 3 auth layers before cluster-admin: Cloudflare Access + oauth2-proxy + token login. Downgraded from CRITICAL to LOW. |
 | Longhorn and Supabase Studio restricted to admin-only | `6ede8e9` | oauth2-proxy email allowlist now uses `admin_emails` only. Viewer users cannot access these admin tools. |
@@ -138,7 +139,7 @@ used on the internal cluster network.
 | LOW | OAuth rate limiting absent on `/authorize`, `/callback`, `/token` | `open-brain-mcp/oauth.py` | Add application-level throttling or ingress `limit-rps` |
 | LOW | State parameter passed through without format validation | `open-brain-mcp/oauth.py:166` | Add length/format check |
 | INFO | Dex client secrets stored in SealedSecret | `additions/argocd/argocd-dex-secret.yaml` | Compliant |
-| INFO | Two-tier email RBAC (`admin_emails`/`viewer_emails`) restricts access | `values.yaml:46-60` | Good practice — implemented |
+| INFO | Admin email RBAC (`admin_emails`) restricts access; viewer is the default for authenticated non-admins | `values.yaml` | Good practice — implemented (`viewer_emails` removed 2026-04-11) |
 | INFO | open-brain-mcp PKCE S256 implementation correct per RFC 7636 | `open-brain-mcp/oauth.py:189-194` | Compliant |
 | INFO | Each service has its own Dex client (blast radius isolation) | `additions/argocd/argocd-cm.yml:33-48` | Good practice |
 
@@ -203,8 +204,8 @@ Two email lists in `kubernetes-services/values.yaml` control access:
 
 - **`admin_emails`** — full access everywhere (also in `group_vars/all.yml`
   for Ansible-rendered ArgoCD RBAC)
-- **`viewer_emails`** — read-only access to Dex-authenticated services;
-  blocked from oauth2-proxy-gated services
+- **Viewer role** — the default for any authenticated non-admin; no
+  separate list in the repo (entry gated by Cloudflare Access)
 
 Services use two parallel auth paths:
 
@@ -245,11 +246,11 @@ Services use two parallel auth paths:
 
 ### Resolved
 
-- ~~**Decouple admin emails from auth allowlist**~~ — Done. Split
-  `oauth2_emails` into `admin_emails` + `viewer_emails`. Viewer users get
-  read-only access to Dex-authenticated services; admin-only services
-  (Headlamp, Longhorn, Supabase Studio) are gated by oauth2-proxy restricted
-  to `admin_emails`.
+- ~~**Decouple admin emails from auth allowlist**~~ — Done. `admin_emails`
+  grants admin access; all other authenticated users get viewer/read-only
+  roles. Admin-only services (Headlamp, Supabase Studio) are gated by
+  oauth2-proxy restricted to `admin_emails`. *(`viewer_emails` removed
+  2026-04-11 — entry now gated by Cloudflare Access.)*
 
 - ~~**Replace cluster-admin dashboard binding**~~ — Downgraded. Headlamp's
   cluster-admin SA is acceptable because it's behind three auth layers


### PR DESCRIPTION
## Summary

- `viewer_emails` was removed from `values.yaml` in #333, along with
  `scripts/add-viewer` and the `just add-viewer` recipe
- 8 docs files still referenced it — this PR cleans them up
- Docs now reflect the current model: admin via `admin_emails`, viewer
  is the default for any authenticated non-admin, entry gated by
  Cloudflare Access
- `security-review.md` gets "removed 2026-04-11" annotations on
  historical entries rather than rewriting the audit trail

## Test plan

- [ ] `python -m sphinx docs docs/_build` passes
- [ ] No remaining `viewer_emails` references outside historical notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)