### PR TITLE
fix: correct architecture showcase link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ pinned to a specific node — with **daily and weekly CronJob backups to
 NFS** on a NAS. This keeps operations simple (no replicated CSI driver)
 while still surviving cluster rebuilds and giving off-cluster
 point-in-time restore. See the
-[**Interactive Architecture Showcase**](https://gilesknap.github.io/tpi-k3s-ansible/architecture.html)
+[**Interactive Architecture Showcase**](https://gilesknap.github.io/tpi-k3s-ansible/_static/architecture.html)
 for a visual tour, the [architecture explanation](https://gilesknap.github.io/tpi-k3s-ansible/explanations/architecture.html)
 for the layered model, and the
 [services reference](https://gilesknap.github.io/tpi-k3s-ansible/reference/services.html)


### PR DESCRIPTION
## Summary
- The Interactive Architecture Showcase link in README.md pointed to `/architecture.html`, which returns a 404
- Corrected to `/_static/architecture.html` where Sphinx actually serves the file

## Test plan
- [x] Verified `_static/architecture.html` loads correctly on GitHub Pages
- [ ] Confirm link works from rendered README after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)