### PR TITLE
feat: add architecture showcase link to landing page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,8 @@ workflow, including cherry-picking the reseal commit back.
 - ArgoCD app templates: `kubernetes-services/templates/`
 - Extra manifests: `kubernetes-services/additions/` (incl. `ingress/` sub-chart)
 - SSH to nodes: `ssh ansible@<node>` (not root)
+- ArgoCD namespace: `argo-cd` (hyphenated, not `argocd`)
+- kubectl works in the devcontainer — never SSH to nodes for kubectl
 
 ## Conventions
 

--- a/kubernetes-services/additions/home/templates/manifests.yaml
+++ b/kubernetes-services/additions/home/templates/manifests.yaml
@@ -129,6 +129,30 @@ data:
           text-decoration: none;
         }
         .footer a:hover { text-decoration: underline; }
+        .showcase-link {
+          display: block;
+          margin: 2rem auto 0;
+          max-width: 900px;
+          width: 100%;
+          text-align: center;
+        }
+        .showcase-link a {
+          display: inline-block;
+          padding: 0.6rem 1.8rem;
+          background: linear-gradient(135deg, #7c3aed, #6366f1);
+          color: #e0e7ff;
+          border-radius: 8px;
+          text-decoration: none;
+          font-size: 0.95rem;
+          font-weight: 500;
+          letter-spacing: 0.02em;
+          transition: background 0.2s, box-shadow 0.2s;
+          box-shadow: 0 0 12px rgba(99, 102, 241, 0.25);
+        }
+        .showcase-link a:hover {
+          background: linear-gradient(135deg, #6d28d9, #4f46e5);
+          box-shadow: 0 0 20px rgba(99, 102, 241, 0.45);
+        }
       </style>
     </head>
     <body>
@@ -189,8 +213,10 @@ data:
       <div class="footer">
         <span>K3s Cluster</span>
         <a href="https://gilesknap.github.io/tpi-k3s-ansible/">Docs</a>
-        <a href="https://gilesknap.github.io/tpi-k3s-ansible/architecture.html">Architecture</a>
         <a href="{{ .Values.repo_remote | trimSuffix ".git" }}">GitHub</a>
+      </div>
+      <div class="showcase-link">
+        <a href="https://gilesknap.github.io/tpi-k3s-ansible/_static/architecture.html">&#10024; Interactive Architecture Showcase</a>
       </div>
       <script>
         (function() {


### PR DESCRIPTION
## Summary
- Adds a prominent gradient button below the footer linking to the Interactive Architecture Showcase
- Fixes the broken `_static/` path in the old footer architecture link
- Removes the duplicate architecture link from the footer (now standalone below)
- Adds kubectl/namespace notes to CLAUDE.md

## Test plan
- [ ] Verify landing page shows showcase button after ArgoCD sync
- [ ] Confirm button links to `_static/architecture.html` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)