### PR TITLE
style: tone down architecture showcase link

### DIFF
--- a/kubernetes-services/additions/home/templates/manifests.yaml
+++ b/kubernetes-services/additions/home/templates/manifests.yaml
@@ -137,21 +137,14 @@ data:
           text-align: center;
         }
         .showcase-link a {
-          display: inline-block;
-          padding: 0.6rem 1.8rem;
-          background: linear-gradient(135deg, #7c3aed, #6366f1);
-          color: #e0e7ff;
-          border-radius: 8px;
+          color: #818cf8;
           text-decoration: none;
           font-size: 0.95rem;
           font-weight: 500;
           letter-spacing: 0.02em;
-          transition: background 0.2s, box-shadow 0.2s;
-          box-shadow: 0 0 12px rgba(99, 102, 241, 0.25);
         }
         .showcase-link a:hover {
-          background: linear-gradient(135deg, #6d28d9, #4f46e5);
-          box-shadow: 0 0 20px rgba(99, 102, 241, 0.45);
+          text-decoration: underline;
         }
       </style>
     </head>


### PR DESCRIPTION
## Summary
- Replace gradient button with a simple text link matching the footer style
- Keeps the sparkle icon, size, and position below the footer

## Test plan
- [ ] Verify link is visible but not distracting after ArgoCD sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)