### PR TITLE
fix: use regular merge for PRs tidied with /pr-squash

### DIFF
--- a/.claude/commands/pr-squash.md
+++ b/.claude/commands/pr-squash.md
@@ -84,3 +84,5 @@ commits on a new branch, then opening a pull request.
   auto-resolving.
 - Never force-push or modify the original branch.
 - If a `-squash` branch already exists, ask the user before overwriting.
+- When merging a PR created by this command, use `gh pr merge --merge`
+  (not `--squash`) to preserve the curated commit structure.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,10 +10,11 @@
   `ansible-playbook --tags cluster` (sanctioned bootstrap/update path);
   `kubectl annotate ... argocd.argoproj.io/refresh=hard` (force repo re-fetch).
 - **Never commit to `main`** — work in branches, merge when verified. Use
-  `/pr-squash` to tidy history before merging.
-- **Rebase over `main` before new work** — squash-merged commits have
-  different SHAs from the originals, so skipping rebase causes phantom
-  conflicts.
+  `/pr-squash` to tidy history before merging, then merge with
+  `gh pr merge --merge` to preserve the curated commits. Only use
+  `--squash` for PRs that haven't been through `/pr-squash`.
+- **Rebase over `main` before new work** — merged commits have different
+  SHAs from the originals, so skipping rebase causes phantom conflicts.
 - **Chrome browser is not incognito** — never navigate to Google services.
   For GitHub: OAuth "Grant Access" / "Authorize" clicks are OK (they only
   redirect back to the cluster), but do not modify any GitHub resources


### PR DESCRIPTION
## Summary

- Updated CLAUDE.md: use `gh pr merge --merge` after `/pr-squash`, only `--squash` for untidied PRs
- Updated pr-squash command: added merge guidance in edge cases section

Closes #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)