### PR TITLE
docs: add home-lan to DNS record list

### DIFF
--- a/docs/how-to/cloudflare-tunnel.md
+++ b/docs/how-to/cloudflare-tunnel.md
@@ -138,7 +138,13 @@ Cloudflare will round-robin across them:
 
 Replace the IPs with the LAN addresses of your worker nodes (e.g.
 `192.168.1.82`, `.83`, `.84`). Services to add: `argocd`, `grafana`,
-`headlamp`, `oauth2`, `open-webui`, `rkllama`.
+`headlamp`, `home-lan`, `oauth2`, `open-webui`, `rkllama`.
+
+:::{note}
+`home-lan` backs the landing page's LAN-detection probe. The page
+JavaScript fetches `https://home-lan.<domain>/healthz` — it only
+resolves when the browser is on the LAN, enabling LAN-only UI elements.
+:::
 
 These resolve to private RFC-1918 addresses — only reachable from your LAN.
 For a single-node cluster, one A record per service is sufficient.


### PR DESCRIPTION
## Summary
- Add `home-lan` to the grey-cloud DNS service list in the Cloudflare tunnel guide
- Add a note explaining its purpose (landing page LAN-detection probe)

## Test plan
- [x] `just check` passes (lint + docs build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)