### PR TITLE
docs: promote hosts.yml to a first-class fork-edit file

### DIFF
--- a/docs/explanations.md
+++ b/docs/explanations.md
@@ -3,10 +3,9 @@
 Background knowledge covering architecture, design decisions, and how the
 system works.
 
-## Architecture
-
 ```{toctree}
 :maxdepth: 1
+:caption: Architecture
 
 explanations/architecture
 explanations/gitops-flow
@@ -14,10 +13,9 @@ explanations/kubernetes-services
 explanations/ansible-roles
 ```
 
-## Networking & Security
-
 ```{toctree}
 :maxdepth: 1
+:caption: Networking & Security
 
 explanations/networking
 explanations/authentication
@@ -26,26 +24,23 @@ explanations/security
 explanations/security-hardening
 ```
 
-## Open Brain
-
 ```{toctree}
 :maxdepth: 1
+:caption: Open Brain
 
 explanations/open-brain-clients
 ```
 
-## Claude Code
-
 ```{toctree}
 :maxdepth: 1
+:caption: Claude Code
 
 explanations/claude-code-capability
 ```
 
-## Decisions
-
 ```{toctree}
 :maxdepth: 1
+:caption: Decisions
 
 explanations/decisions
 ```

--- a/docs/explanations/claude-code-capability.md
+++ b/docs/explanations/claude-code-capability.md
@@ -64,12 +64,18 @@ every time, without forgetting steps.
 
 ### Configuration concentration
 
-The entire cluster's configuration lives in two files totalling **135 lines**:
+Almost every cluster-level choice lives in two files totalling **135 lines**:
 
-- `group_vars/all.yml` (59 lines) — cluster-level variables: node names,
-  IP addresses, domain, storage paths
+- `group_vars/all.yml` (59 lines) — cluster domain, admin emails, repo URL,
+  storage paths
 - `kubernetes-services/values.yaml` (76 lines) — service toggles and
   version pins
+
+A third file, `inventory/hosts.yml`, owns the hardware topology
+(hostnames, IPs, per-node flags). It is deliberately not templated
+through the other two — hardware varies too much between forks. But
+it is still a small, single place to look when the agent needs to
+know which physical node runs what.
 
 Four boolean flags control which optional services are deployed. When Claude
 needs to enable or disable a service, there is exactly one place to look.
@@ -220,9 +226,9 @@ These are concrete, actionable steps drawn from the patterns above.
    migrations" is a wish.
 
 2. **Concentrate configuration.** The fewer files an agent needs to read to
-   understand system state, the fewer mistakes it will make. Two files
-   totalling 135 lines is better than 20 files totalling 2,000 lines, even
-   if the latter is more "modular."
+   understand system state, the fewer mistakes it will make. Two config
+   files plus an inventory file totalling 135 lines is better than 20
+   files totalling 2,000 lines, even if the latter is more "modular."
 
 3. **Use GitOps or equivalent reconciliation.** If mistakes are fixed by
    pushing a commit rather than running manual commands, the blast radius is

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -2,10 +2,9 @@
 
 Task-oriented recipes for common operations and configuration changes.
 
-## Setup
-
 ```{toctree}
 :maxdepth: 1
+:caption: Setup
 
 how-to/fork-this-repo
 how-to/bootstrap-cluster
@@ -17,10 +16,9 @@ how-to/oauth-setup
 how-to/nas-setup
 ```
 
-## Optional Features
-
 ```{toctree}
 :maxdepth: 1
+:caption: Optional Features
 
 how-to/rkllama-models
 how-to/llamacpp-models
@@ -29,10 +27,9 @@ how-to/claude-ai-mcp
 how-to/add-remove-services
 ```
 
-## Operations & Maintenance
-
 ```{toctree}
 :maxdepth: 1
+:caption: Operations & Maintenance
 
 how-to/monitoring
 how-to/backup-restore
@@ -43,10 +40,9 @@ how-to/reflash-rebuild
 how-to/alternative-storage
 ```
 
-## Developer Workflow
-
 ```{toctree}
 :maxdepth: 1
+:caption: Developer Workflow
 
 how-to/work-in-branches
 how-to/claude-code

--- a/docs/how-to/fork-this-repo.md
+++ b/docs/how-to/fork-this-repo.md
@@ -5,18 +5,25 @@ files, push to your own fork, and the playbook + ArgoCD will deploy a
 clone of the cluster against your hardware. This guide walks through
 every file you need to touch.
 
-## The two-file model
+## The three files you must edit
 
-The bulk of cluster-specific configuration lives in just two files:
+Cluster-specific configuration lives in three files. Expect to edit
+all three before your first deploy:
 
 | File | Owns |
 |---|---|
+| `inventory/hosts.yml` | Your hardware: hostnames, IPs, BMC addresses, per-node flags (slot, type, root device, GPU, workstation). |
 | `group_vars/all.yml` | Ansible-side: cluster domain, admin emails, repo URL/branch, host data directories. |
 | `kubernetes-services/values.yaml` | ArgoCD/Helm-side: NFS server, local PV layout, OAuth, supabase release name, image repositories. |
 
-A third file, `inventory/hosts.yml`, owns the node inventory itself —
-hostnames, IPs, BMC addresses. Fork this directly to match your
-hardware (it is **not** templated through values.yaml on purpose).
+`hosts.yml` is deliberately **not** templated through the other two —
+every fork's hardware is different, and the flash/known_hosts roles
+rely on group-name conventions (`<bmc>_nodes`) that don't survive
+templating cleanly. Edit it directly. The node names you choose there
+are referenced from the other two files, so pick them first.
+
+See {doc}`/reference/inventory` for the full list of per-node
+variables and group naming rules.
 
 ## Step-by-step fork
 
@@ -24,7 +31,34 @@ hardware (it is **not** templated through values.yaml on purpose).
 
 Fork `gilesknap/tpi-k3s-ansible` on GitHub, then clone your fork.
 
-### 2. Point the cluster at your fork
+### 2. Edit the inventory
+
+`inventory/hosts.yml` lists every node and BMC. Replace hostnames,
+IPs, MAC addresses, and BMC URLs with your own.
+
+Per-node variables that matter:
+
+- `slot_num` / `type` — for Turing Pi nodes, the physical slot and
+  compute module type (`pi4` / `rk1`).
+- `root_dev` — set to migrate the OS to NVMe; omit for servers
+  already on their target disk.
+- `nvidia_gpu_node: true` — enables the NVIDIA driver and container
+  toolkit on that node. Required for llama.cpp CUDA.
+- `workstation: true` — applies a `NoSchedule` taint. Useful for
+  machines that reboot unexpectedly (only tolerating workloads land
+  there).
+- `node_ip` / `flannel_iface` — required on multi-homed nodes.
+
+Turing Pi node groups **must** be named `<bmc_hostname>_nodes` — the
+flash role uses this convention to discover which nodes belong to
+which BMC. Full reference: {doc}`/reference/inventory`.
+
+The host names you choose here (`node01`, `node02`, `nuc2`, etc.) are
+referenced from `group_vars/all.yml` and
+`kubernetes-services/values.yaml` — pick them before the next two
+steps and keep them consistent across all three files.
+
+### 3. Point the cluster at your fork
 
 In `group_vars/all.yml`:
 
@@ -35,6 +69,7 @@ cluster_domain: <your-domain>
 domain_email: <your-email>  # for letsencrypt
 admin_emails:
   - <your-email>
+control_plane: <your-control-plane-node>  # must match a host in hosts.yml
 ```
 
 In `kubernetes-services/values.yaml`, mirror the admin emails:
@@ -43,13 +78,6 @@ In `kubernetes-services/values.yaml`, mirror the admin emails:
 admin_emails:
   - <your-email>
 ```
-
-### 3. Edit the inventory
-
-`inventory/hosts.yml` lists every node and BMC. Replace hostnames,
-IPs, MAC addresses, and BMC URLs with your own. The host names you
-choose here (`node01`, `node02`, `nuc2`, etc.) are referenced in the
-storage maps below — keep them consistent.
 
 ### 4. Map storage to your nodes
 
@@ -147,7 +175,11 @@ different. Edit the HTML directly to match your LAN.
 
 ## What's NOT templated (by design)
 
-- `inventory/hosts.yml` — fork-specific inventory, edit directly.
+- `inventory/hosts.yml` — hardware topology varies too much between
+  forks to template. Group names (`<bmc>_nodes`) are load-bearing
+  for the flash role, and per-node flags (`root_dev`,
+  `nvidia_gpu_node`, `workstation`) are specific to the physical
+  machines. Edit it directly.
 - Sealed secrets — bound to the cluster controller key, must be
   re-sealed per cluster.
 - Home page LAN service links — too varied per fork to design a


### PR DESCRIPTION
## Summary
- Rewrite `docs/how-to/fork-this-repo.md` from a "two-file model" to a three-file model: `inventory/hosts.yml` is listed first and gets its own step (promoted from step 3 → step 2, ahead of the config files that reference its hostnames).
- Document the per-node flags that actually matter (`slot_num`/`type`, `root_dev`, `nvidia_gpu_node`, `workstation`, `node_ip`/`flannel_iface`) and the load-bearing `<bmc>_nodes` group-name rule, with a pointer to `/reference/inventory`.
- Add `control_plane:` to the `group_vars/all.yml` example — it must match a host in `hosts.yml`.
- Rework the "What's NOT templated" entry for `hosts.yml` to explain *why* (flash role relies on group-name conventions) rather than just "fork-specific".
- Fix the same framing in `docs/explanations/claude-code-capability.md`: "entire cluster's configuration lives in two files" → "Almost every cluster-level choice lives in two files", plus a paragraph acknowledging the inventory as a deliberately-non-templated third file.

## Test plan
- [x] `python -m sphinx -W docs docs/_build` — build succeeded with no warnings
- [ ] Skim rendered `fork-this-repo` and `claude-code-capability` pages
- [ ] Confirm existing tutorials (`getting-started-tpi`/`getting-started-generic`) remain consistent — they already have a dedicated inventory step before the shared `common-setup.md` include, so no change needed there

🤖 Generated with [Claude Code](https://claude.com/claude-code)