### PR TITLE
style: teal/slate theme for docs and logo

### DIFF
--- a/docs/_static/architecture.html
+++ b/docs/_static/architecture.html
@@ -8,19 +8,19 @@
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 :root {
-  --bg: #1a1a2e;
-  --card-bg: #16213e;
-  --card-border: #0f3460;
-  --hover-accent: #533483;
+  --bg: #0f172a;
+  --card-bg: #1e293b;
+  --card-border: #334155;
+  --hover-accent: #134e4a;
   --text: #e0e0e0;
-  --text-muted: #a0a0b8;
-  --layer1: #a855f7;
-  --layer2: #6366f1;
+  --text-muted: #94a3b8;
+  --layer1: #0d9488;
+  --layer2: #0891b2;
   --layer3: #3b82f6;
   --layer4: #06b6d4;
   --layer5: #f59e0b;
   --layer6: #10b981;
-  --layer7: #818cf8;
+  --layer7: #67e8f9;
   --font: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   --mono: 'SF Mono', 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
 }
@@ -77,8 +77,8 @@ body {
 }
 
 @keyframes glowPulse {
-  0%, 100% { box-shadow: 0 0 15px rgba(168, 85, 247, 0.15); }
-  50%      { box-shadow: 0 0 30px rgba(168, 85, 247, 0.35); }
+  0%, 100% { box-shadow: 0 0 15px rgba(13, 148, 136, 0.15); }
+  50%      { box-shadow: 0 0 30px rgba(13, 148, 136, 0.35); }
 }
 
 .terminal-bar {
@@ -144,8 +144,8 @@ body {
 /* Safety callout ----------------------------------------- */
 .safety-callout {
   display: inline-block;
-  background: rgba(168, 85, 247, 0.08);
-  border: 1px solid rgba(168, 85, 247, 0.25);
+  background: rgba(13, 148, 136, 0.08);
+  border: 1px solid rgba(13, 148, 136, 0.25);
   border-radius: 8px;
   padding: 0.75rem 1.5rem;
   font-size: 0.9rem;
@@ -575,7 +575,7 @@ body {
   var layers = [
     {
       name: 'Execution Environment',
-      accent: '#a855f7',
+      accent: '#0d9488',
       openByDefault: true,
       components: [
         {
@@ -676,7 +676,7 @@ body {
     },
     {
       name: 'GitOps Pipeline',
-      accent: '#6366f1',
+      accent: '#0891b2',
       openByDefault: false,
       components: [
         {
@@ -1040,7 +1040,7 @@ body {
     },
     {
       name: 'Landing Page',
-      accent: '#818cf8',
+      accent: '#67e8f9',
       openByDefault: false,
       components: [
         {

--- a/docs/_static/logo.svg
+++ b/docs/_static/logo.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <defs>
     <radialGradient id="bg" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#a855f7"/>
-      <stop offset="100%" stop-color="#1a1a2e"/>
+      <stop offset="0%" stop-color="#0d9488"/>
+      <stop offset="100%" stop-color="#0f172a"/>
     </radialGradient>
     <filter id="gl">
       <feGaussianBlur stdDeviation="1.5" result="b"/>
@@ -10,7 +10,7 @@
     </filter>
   </defs>
   <circle cx="32" cy="32" r="30" fill="url(#bg)"/>
-  <g filter="url(#gl)" stroke="#818cf8" stroke-width="1.5" fill="none">
+  <g filter="url(#gl)" stroke="#64748b" stroke-width="1.5" fill="none">
     <line x1="32" y1="32" x2="32" y2="10"/>
     <line x1="32" y1="32" x2="51" y2="21"/>
     <line x1="32" y1="32" x2="51" y2="43"/>
@@ -19,7 +19,7 @@
     <line x1="32" y1="32" x2="13" y2="21"/>
   </g>
   <g filter="url(#gl)">
-    <circle cx="32" cy="32" r="5" fill="#c084fc"/>
+    <circle cx="32" cy="32" r="5" fill="#14b8a6"/>
     <circle cx="32" cy="10" r="3.5" fill="#38bdf8"/>
     <circle cx="51" cy="21" r="3.5" fill="#38bdf8"/>
     <circle cx="51" cy="43" r="3.5" fill="#38bdf8"/>


### PR DESCRIPTION
## Summary
- Replaced the purple (`#a855f7`) accent palette with teal/slate (`#0d9488` / `#334155`) across the logo SVG and architecture showcase
- Updated all CSS variables, glow animations, safety callout, and JS layer accent colors
- Layers 3–6 (blue, cyan, amber, emerald) kept as-is — they complement the new scheme

## Why
Purple is heavily associated with AI product marketing ("AI slop"). Teal/slate reads as infrastructure/networking tooling, which better fits a K3s homelab project.

## Test plan
- [x] `just check` passes (ansible-lint + sphinx-build)
- [x] Logo viewed in browser — teal gradient, no purple
- [x] Architecture showcase viewed in browser — all accents updated, terminal glow and safety callout use teal
- [x] No remaining purple hex values in `docs/_static/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)