### PR TITLE
style: teal/slate theme for landing page and error templates

### DIFF
--- a/kubernetes-services/additions/home/templates/manifests.yaml
+++ b/kubernetes-services/additions/home/templates/manifests.yaml
@@ -34,7 +34,7 @@ data:
         * { margin: 0; padding: 0; box-sizing: border-box; }
         body {
           font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-          background: #1a1a2e;
+          background: #0f172a;
           color: #e0e0e0;
           min-height: 100vh;
           display: flex;
@@ -52,7 +52,7 @@ data:
         .section-heading {
           font-weight: 300;
           margin: 2.5rem 0 1rem;
-          color: #a0a0b8;
+          color: #94a3b8;
           font-size: 1.1rem;
           letter-spacing: 0.05em;
         }
@@ -65,8 +65,8 @@ data:
         }
         .card {
           display: block;
-          background: #16213e;
-          border: 1px solid #0f3460;
+          background: #1e293b;
+          border: 1px solid #334155;
           border-radius: 8px;
           padding: 1.25rem;
           text-decoration: none;
@@ -74,8 +74,8 @@ data:
           transition: background 0.2s, border-color 0.2s;
         }
         .card:hover {
-          background: #1a2a50;
-          border-color: #533483;
+          background: #1e3a4a;
+          border-color: #134e4a;
         }
         .card h2 {
           font-size: 1.1rem;
@@ -85,7 +85,7 @@ data:
         }
         .card p {
           font-size: 0.85rem;
-          color: #a0a0b8;
+          color: #94a3b8;
           line-height: 1.4;
         }
         .badge {
@@ -99,7 +99,7 @@ data:
           text-transform: uppercase;
           letter-spacing: 0.03em;
         }
-        .badge-oauth { background: #533483; color: #d8b4fe; }
+        .badge-oauth { background: #134e4a; color: #5eead4; }
         .badge-sso { background: #1e3a5f; color: #7dd3fc; }
         .badge-lan { background: #3a3a3a; color: #888; font-size: 0.6rem; }
         .card-lan.disabled {
@@ -114,7 +114,7 @@ data:
         .footer {
           margin-top: 3rem;
           padding-top: 1.5rem;
-          border-top: 1px solid #0f3460;
+          border-top: 1px solid #334155;
           max-width: 900px;
           width: 100%;
           display: flex;
@@ -125,7 +125,7 @@ data:
           color: #606080;
         }
         .footer a {
-          color: #818cf8;
+          color: #2dd4bf;
           text-decoration: none;
         }
         .footer a:hover { text-decoration: underline; }
@@ -137,7 +137,7 @@ data:
           text-align: center;
         }
         .showcase-link a {
-          color: #818cf8;
+          color: #2dd4bf;
           text-decoration: none;
           font-size: 0.95rem;
           font-weight: 500;
@@ -239,8 +239,8 @@ data:
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
       <defs>
         <radialGradient id="bg" cx="50%" cy="50%" r="50%">
-          <stop offset="0%" stop-color="#a855f7"/>
-          <stop offset="100%" stop-color="#1a1a2e"/>
+          <stop offset="0%" stop-color="#0d9488"/>
+          <stop offset="100%" stop-color="#0f172a"/>
         </radialGradient>
         <filter id="gl">
           <feGaussianBlur stdDeviation="1.5" result="b"/>
@@ -248,7 +248,7 @@ data:
         </filter>
       </defs>
       <circle cx="32" cy="32" r="30" fill="url(#bg)"/>
-      <g filter="url(#gl)" stroke="#818cf8" stroke-width="1.5" fill="none">
+      <g filter="url(#gl)" stroke="#64748b" stroke-width="1.5" fill="none">
         <line x1="32" y1="32" x2="32" y2="10"/>
         <line x1="32" y1="32" x2="51" y2="21"/>
         <line x1="32" y1="32" x2="51" y2="43"/>
@@ -257,7 +257,7 @@ data:
         <line x1="32" y1="32" x2="13" y2="21"/>
       </g>
       <g filter="url(#gl)">
-        <circle cx="32" cy="32" r="5" fill="#c084fc"/>
+        <circle cx="32" cy="32" r="5" fill="#14b8a6"/>
         <circle cx="32" cy="10" r="3.5" fill="#38bdf8"/>
         <circle cx="51" cy="21" r="3.5" fill="#38bdf8"/>
         <circle cx="51" cy="43" r="3.5" fill="#38bdf8"/>

--- a/kubernetes-services/additions/oauth2-proxy/error-templates.yaml
+++ b/kubernetes-services/additions/oauth2-proxy/error-templates.yaml
@@ -15,7 +15,7 @@ data:
         * { margin: 0; padding: 0; box-sizing: border-box; }
         body {
           font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-          background: #1a1a2e;
+          background: #0f172a;
           color: #e0e0e0;
           min-height: 100vh;
           display: flex;
@@ -41,31 +41,31 @@ data:
         }
         .message {
           font-size: 1rem;
-          color: #a0a0b8;
+          color: #94a3b8;
           line-height: 1.6;
           margin-bottom: 2rem;
         }
         .card {
-          background: #16213e;
-          border: 1px solid #0f3460;
+          background: #1e293b;
+          border: 1px solid #334155;
           border-radius: 8px;
           padding: 1.25rem;
           margin-bottom: 1.5rem;
         }
         .card p {
           font-size: 0.85rem;
-          color: #a0a0b8;
+          color: #94a3b8;
           line-height: 1.4;
         }
         .code {
           display: inline-block;
-          background: #16213e;
-          border: 1px solid #0f3460;
+          background: #1e293b;
+          border: 1px solid #334155;
           border-radius: 4px;
           padding: 0.2rem 0.6rem;
           font-family: monospace;
           font-size: 0.9rem;
-          color: #818cf8;
+          color: #2dd4bf;
         }
         a {
           color: #38bdf8;
@@ -73,7 +73,7 @@ data:
           transition: color 0.2s;
         }
         a:hover {
-          color: #818cf8;
+          color: #2dd4bf;
         }
       </style>
     </head>


### PR DESCRIPTION
## Summary
- Applied teal/slate palette to the home dashboard (backgrounds, card borders, hover states, OAuth badges, links, embedded logo SVG)
- Applied matching theme to the oauth2-proxy error page
- Companion to #366 which covers the docs site (architecture showcase + logo)

## Why
Purple is heavily associated with AI product marketing. Teal/slate reads as infrastructure tooling, matching the docs theme from #366.

## Test plan
- [x] `just check` passes (ansible-lint + sphinx-build)
- [x] No remaining purple hex values in either file
- [ ] Verify on live cluster after ArgoCD sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)