### PR TITLE
feat: Claude-scoped ansible SSH key for cluster nodes

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -47,6 +47,10 @@
 		// host SSH agent via SSH_AUTH_SOCK and copies host known_hosts on
 		// attach. Claude is isolated from both by the bwrap sandbox.
 		"source=iac2-kube,target=/root/.kube,type=volume",
+		// Claude-scoped SSH keypair for ansible on cluster nodes. Separate
+		// from the user's personal keys (which never enter the sandbox).
+		// Bootstrap with `just claude-ssh-bootstrap`.
+		"source=iac2-claude-ssh,target=/root/.config/claude-ssh,type=volume",
 		// Mount in the user terminal config folder so it can be edited
 		{
 			"source": "${localEnv:HOME}/.config/terminal-config",

--- a/justfile
+++ b/justfile
@@ -102,6 +102,28 @@ create-prometheus-admission-secret:
 promote target=invocation_directory():
     bash .devcontainer/claude-sandbox/promote.sh {{ target }}
 
+# Generate (if absent) and deploy Claude's ansible-account SSH key to all
+# cluster nodes. `revoke` removes it. The keypair lives in the iac2-claude-ssh
+# podman volume so it persists across container rebuilds. Run this from the
+# outer devcontainer — needs the host SSH agent to reach the nodes the first
+# time. After deploy, the sandbox can ansible-playbook with this key.
+claude-ssh-bootstrap action="deploy":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    keydir=/root/.config/claude-ssh
+    keyfile="$keydir/id_ed25519"
+    case "{{ action }}" in
+        deploy) state=present ;;
+        revoke) state=absent ;;
+        *) echo "Usage: just claude-ssh-bootstrap [deploy|revoke]" >&2; exit 1 ;;
+    esac
+    if [ ! -f "$keyfile" ]; then
+        mkdir -p "$keydir"
+        chmod 700 "$keydir"
+        ssh-keygen -t ed25519 -f "$keyfile" -N "" -C "claude-sandbox@$(hostname)"
+    fi
+    ansible-playbook pb_all.yml --tags claude_key -e "claude_pubkey_state=$state"
+
 # Authenticate gh CLI with a GitHub PAT (token not stored in shell history).
 gh-auth:
     #!/usr/bin/env bash

--- a/pb_all.yml
+++ b/pb_all.yml
@@ -45,3 +45,15 @@
   roles:
     - role: cluster
   tags: cluster
+
+- name: Manage Claude sandbox's pub key on the ansible account
+  hosts: all_nodes
+  gather_facts: false
+  tasks:
+    - name: Add or remove Claude pubkey from ansible user authorized_keys
+      ansible.posix.authorized_key:
+        user: "{{ ansible_account }}"
+        state: "{{ claude_pubkey_state | default('present') }}"
+        key: "{{ lookup('file', claude_ansible_pubkey_path | default('/root/.config/claude-ssh/id_ed25519.pub')) }}"
+        comment: claude-sandbox
+  tags: claude_key


### PR DESCRIPTION
## Summary

- Add a dedicated ed25519 keypair the sandboxed Claude can use to reach the `ansible` account on cluster nodes, isolated from the user's personal SSH keys (which include GitHub-org-admin reach).
- Key lives in a new `iac2-claude-ssh` podman volume so it persists across container rebuilds.
- `just claude-ssh-bootstrap` generates the key (once) and deploys the pubkey via the new `claude_key` tag; `revoke` removes it. The play uses `ansible.posix.authorized_key` with a `claude-sandbox` comment so revocation only touches Claude's own line — never the user's personal ansible key.

This is part 1 of 2. Part 2 (`claude-sandbox-cluster-binds`) updates the bwrap sandbox to bind the key + admin kubeconfig in, and updates the skill/verification docs to record the deliberate, homelab-scoped reach.

## Activation

Run from the **outer** devcontainer (needs host SSH agent for first deploy):

1. Rebuild devcontainer to pick up the `iac2-claude-ssh` volume mount.
2. `just claude-ssh-bootstrap` — keygen + deploy pubkey to all `all_nodes`.

After deploy, the sandbox can `ansible-playbook ...` against the cluster without ever seeing the user's personal keys.

## Test plan

- [ ] Devcontainer rebuilds cleanly with the new volume mount.
- [ ] `just claude-ssh-bootstrap` generates `~/.config/claude-ssh/id_ed25519` and runs the play green.
- [ ] `ssh -i ~/.config/claude-ssh/id_ed25519 ansible@node01` succeeds (from outside the sandbox).
- [ ] `just claude-ssh-bootstrap revoke` removes only the `claude-sandbox`-commented line from `authorized_keys` on every node.
- [ ] `just check` stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)