### PR TITLE
feat: bind cluster-reach paths into the Claude sandbox

### DIFF
--- a/.claude/commands/verify-sandbox.md
+++ b/.claude/commands/verify-sandbox.md
@@ -57,19 +57,29 @@ grep -q '^NoNewPrivs:[[:space:]]*1$' /proc/self/status
 `$HOME` (typically `/root`) is a tmpfs with only `.claude`,
 `.claude.json` (Claude Code's account state), and (optionally)
 `.cache` bound back in, plus a `.config` intermediate tmpfs that holds
-the `gh` / `glab-cli` credential binds. Claude Code itself writes
-`.local/{bin,share,state}/claude` and a `.local/share/applications`
-`.desktop` URL handler into the tmpfs on first launch, so `.local` is
-also expected (contents live in the tmpfs, not bound from the host).
-The defence-in-depth file masks (checks 14–15) also bind `/dev/null`
-over `.netrc`, `.Xauthority`, and `.ICEauthority` — so those names
-are expected to appear too, as size-zero entries (which checks 14–15
-verify; `.ICEauthority` is masked without a dedicated check because
-it shares the X11 cookie attack surface). Anything else under `$HOME`,
-or anything besides `gh` / `glab-cli` under `$HOME/.config`, means the
-strict-under-/root inversion regressed. `.gitconfig` is no longer
-masked — it doesn't normally appear under the tmpfs `$HOME`, but the
-allow-list still permits the name in case a tool drops one.
+the `gh` / `glab-cli` / `claude-ssh` credential binds. Claude Code
+itself writes `.local/{bin,share,state}/claude` and a
+`.local/share/applications` `.desktop` URL handler into the tmpfs on
+first launch, so `.local` is also expected (contents live in the
+tmpfs, not bound from the host). The defence-in-depth file masks
+(checks 14–15) also bind `/dev/null` over `.netrc`, `.Xauthority`,
+and `.ICEauthority` — so those names are expected to appear too, as
+size-zero entries (which checks 14–15 verify; `.ICEauthority` is
+masked without a dedicated check because it shares the X11 cookie
+attack surface).
+
+Three further allowlisted entries reach the cluster from the
+sandbox (Invariant 3 in the claude-sandbox skill records why this
+is deliberate, homelab-scoped, and not a regression):
+`.kube` (admin kubeconfig), `bin` (ansible-installed CLI tools),
+`.ssh` (file-bind of `known_hosts` only, no directory bind so no
+private key can leak in).
+
+Anything else under `$HOME`, or anything besides `gh` / `glab-cli` /
+`claude-ssh` under `$HOME/.config`, means the strict-under-/root
+inversion regressed. `.gitconfig` is no longer masked — it doesn't
+normally appear under the tmpfs `$HOME`, but the allow-list still
+permits the name in case a tool drops one.
 
 Claude Code, left to its own devices, would drop a Chrome native-
 messaging-host manifest (`com.anthropic.claude_code_browser_extension.
@@ -89,7 +99,7 @@ regressed.
 # .config intermediate tmpfs for the selectively-exposed gh/glab
 # binds, the .local tree Claude Code writes into the tmpfs at
 # runtime, and the four masked dotfiles intentionally bound to /dev/null.
-extras="$(ls -A "$HOME" 2>/dev/null | grep -vxE '\.claude|\.claude\.json|\.cache|\.config|\.local|\.gitconfig|\.netrc|\.Xauthority|\.ICEauthority' || true)"
+extras="$(ls -A "$HOME" 2>/dev/null | grep -vxE '\.claude|\.claude\.json|\.cache|\.config|\.local|\.gitconfig|\.netrc|\.Xauthority|\.ICEauthority|\.kube|\.ssh|bin' || true)"
 [ -z "$extras" ] || exit 1
 # When .config is present (bwrap intermediate for the credential
 # binds), assert it contains only the trusted subdirs — anything else
@@ -97,8 +107,16 @@ extras="$(ls -A "$HOME" 2>/dev/null | grep -vxE '\.claude|\.claude\.json|\.cache
 # or the shadow's --no-chrome injection regressed (browser dirs from
 # Claude Code's Chrome native-messaging-host self-registration).
 if [ -d "$HOME/.config" ]; then
-    config_extras="$(ls -A "$HOME/.config" 2>/dev/null | grep -vxE 'gh|glab-cli' || true)"
+    config_extras="$(ls -A "$HOME/.config" 2>/dev/null | grep -vxE 'gh|glab-cli|claude-ssh' || true)"
     [ -z "$config_extras" ]
+fi
+# When .ssh is present, only the file-bind of known_hosts is allowed.
+# A directory bind of ~/.ssh would expose any private key the user
+# later drops in — Invariant 3 in the claude-sandbox skill refuses
+# this. A regression would surface as extra files here.
+if [ -d "$HOME/.ssh" ]; then
+    ssh_extras="$(ls -A "$HOME/.ssh" 2>/dev/null | grep -vxE 'known_hosts' || true)"
+    [ -z "$ssh_extras" ]
 fi
 ```
 

--- a/.claude/skills/claude-sandbox/SKILL.md
+++ b/.claude/skills/claude-sandbox/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: claude-sandbox
-description: Architecture decisions and historical reversals for this repo's bwrap-based Claude sandbox. Covers real claude off PATH, container-scoped PATs, host-only SSH state (VS Code forwards agent + known_hosts, sandbox `--clearenv` strips both), Ubuntu-24.04 CI bwrap workarounds, dogfood ≈ guest, the `just promote` three-layer model (no JSONC editing), and two walked-back paths (Python orchestration; embedding in python-copier-template). Surface before edits to `.devcontainer/claude-sandbox/{claude-shadow,install.sh,promote.sh}`, `install`, `tests/`, `.github/workflows/ci.yml`, or `.claude/commands/verify-sandbox.md`; or before any suggestion to re-introduce Python tooling, embed in python-copier-template, persist gh/glab PATs across containers, re-introduce an in-container ssh-agent or `/root/.ssh` volume, or auto-edit JSONC devcontainer.json.
+description: Architecture decisions and historical reversals for this repo's bwrap-based Claude sandbox. Covers real claude off PATH, container-scoped PATs, the homelab-scoped cluster reach (admin kubeconfig + Claude-only ansible key bound in; user's personal SSH agent + ~/.ssh stay masked), Ubuntu-24.04 CI bwrap workarounds, dogfood ≈ guest, the `just promote` three-layer model (no JSONC editing), and two walked-back paths (Python orchestration; embedding in python-copier-template). Surface before edits to `.devcontainer/claude-sandbox/{claude-shadow,install.sh,promote.sh}`, `install`, `tests/`, `.github/workflows/ci.yml`, or `.claude/commands/verify-sandbox.md`; or before any suggestion to re-introduce Python tooling, embed in python-copier-template, persist gh/glab PATs across containers, forward the host SSH agent into the sandbox, restore `iac2-ssh`-style host-key volumes, or auto-edit JSONC devcontainer.json.
 ---
 
 # claude-sandbox
@@ -56,44 +56,69 @@ not repo-scoped credentials. Don't conflate the two.
 If a future request says "stop re-pasting the PAT" — surface this
 tradeoff before implementing the shortcut.
 
-## Invariant 3 — host SSH state stays on the host
+## Invariant 3 — personal SSH agent stays on the host; cluster reach is Claude-scoped
 
-SSH keys, `~/.ssh/known_hosts`, and the running `ssh-agent` all live on the
-host. VS Code Dev Containers auto-forwards `SSH_AUTH_SOCK` and copies the
-host's `~/.ssh/known_hosts` into the container on attach (observed since
-~2020, devcontainers/cli#474 — undocumented but stable). Ansible inside the
-outer devcontainer uses both transparently — `ansible-playbook` commands
-do **not** need a `SSH_AUTH_SOCK="/tmp/ssh-agent.sock"` prefix.
+The host's ssh-agent holds keys with multi-org admin reach (GitHub
+orgs, etc). VS Code Dev Containers auto-forwards `SSH_AUTH_SOCK` and
+copies `~/.ssh/known_hosts` into the outer container on attach
+(observed since ~2020, devcontainers/cli#474 — undocumented but
+stable). Ansible inside the outer devcontainer uses both
+transparently.
 
-Claude inside the bwrap sandbox sees neither: `--clearenv` drops the
-forwarded socket, and the strict-under-`/root` tmpfs overlay masks
-`/root/.ssh` (it's deliberately not in the bind-back allowlist alongside
-`.claude`, `.cache`, `.config/gh`, `.config/glab-cli`, `.local/share/uv`).
-That asymmetry is the whole point — your terminals get the host agent,
-prompt-injection in Claude can't.
+The sandbox **must not** forward the host agent — sharing a keyring
+shares every key in it. Personal SSH keys never reach the sandbox.
+
+**What IS bound into the sandbox** (deliberate, homelab-scoped reach
+into the cluster — accepted blast radius, not a leak):
+
+| Path                       | Source                                | Why                                                  |
+|----------------------------|---------------------------------------|------------------------------------------------------|
+| `~/.kube`                  | `iac2-kube` podman volume             | k3s admin kubeconfig — full cluster reach.           |
+| `~/.config/claude-ssh`     | `iac2-claude-ssh` podman volume       | Dedicated ed25519 keypair just for Claude → ansible. |
+| `~/bin`                    | `iac2-bin` podman volume              | Ansible-installed CLI tools (kubectl, helm, etc).    |
+| `~/.ssh/known_hosts`       | File bind only                        | Cluster node fingerprints, non-sensitive.            |
+
+Plus `ANSIBLE_SSH_PRIVATE_KEY_FILE` is `--setenv`'d at the key path
+so `ansible-playbook` inside the sandbox authenticates with the
+Claude-scoped key automatically.
+
+The Claude-scoped key is **separate** from the user's personal keys
+and only authorised on the `ansible` user of cluster nodes. Revoke
+with `just claude-ssh-bootstrap revoke` — touches only the
+`claude-sandbox`-commented `authorized_keys` line, not the user's
+own ansible key.
 
 **Refuse as regressions:**
-- An `iac2-ssh`-style Docker volume mounted at `/root/.ssh` to "persist
-  keys across rebuilds". The volume predated the sandbox (added 2024-12-23,
-  PR-era commit `4b9861d`; sandbox arrived March 2026) and was removed in
-  PR for `add-claude-sandbox`. Re-adding it adds a key-storage path that
-  collides with VS Code's automatic forwarding and re-creates the
-  "scp host key into container" ceremony.
-- An in-container ssh-agent helper (`scripts/ssh-agent`, `just ssh-agent`
-  recipe, `/tmp/ssh-agent.sock` socket, `SSH_AUTH_SOCK="/tmp/..."` prefix
-  on ansible commands). All deleted in the same PR. The host agent
-  forwarded by VS Code is the only agent now.
-- Adding `.ssh` to the bwrap shadow's `for rel in ...` bind-back loop. The
-  sandbox MUST stay blind to host SSH state.
+- Forwarding `SSH_AUTH_SOCK` into the sandbox (i.e. `--bind`'ing
+  the socket path or `--setenv SSH_AUTH_SOCK`). This is the
+  load-bearing reason personal keys don't leak — adding it gives
+  prompt-injection access to every key the host agent holds,
+  including the GitHub-org-admin ones.
+- An `iac2-ssh`-style Docker volume mounted at `/root/.ssh`. The
+  Claude-scoped key lives at `~/.config/claude-ssh/`, scoped to
+  the `ansible` user role only; `~/.ssh` is for the user's
+  personal keys and must stay off the sandbox bind-back list.
+- Adding the bare `.ssh` directory to the bind-back loop. Only the
+  `known_hosts` *file* is bound — not the directory. A directory
+  bind would expose any private key the user later drops in.
+- The deleted in-container ssh-agent helpers (`scripts/ssh-agent`,
+  `just ssh-agent` recipe, `/tmp/ssh-agent.sock` socket,
+  `SSH_AUTH_SOCK="/tmp/..."` prefix). The Claude-scoped key works
+  by file path, no agent needed.
 
-**Acceptable swap:** if a future Anthropic-shipped Claude flag needs a key
-inside the sandbox (e.g. for `claude` itself to authenticate somewhere),
-add a Claude-scoped key path, not a re-bind of `~/.ssh`.
+**Why this differs from Invariant 2 (PATs):** PATs are
+container-scoped and re-pasted per rebuild because their blast
+radius (multi-repo GitHub access) is large *and* the user doesn't
+want it persisted. Cluster-admin is a *bigger* blast radius, but
+the user has explicitly accepted it: this is an experimental
+homelab, capability inside the sandbox is the point, and the
+Claude-scoped ansible key isolates the *one* class of credential
+(GitHub-org-admin SSH keys) the user does want to keep out.
 
-Workflow consequence: bare `ssh node01` from the host uses your local
-username (`giles@node01`) — must be `ssh ansible@node01`. Ansible's
-`ansible_user: ansible` handles this for delegated tasks; only matters
-for interactive ssh.
+Workflow consequence: bare `ssh node01` from the host uses your
+local username (`giles@node01`) — must be `ssh ansible@node01`.
+Ansible's `ansible_user: ansible` handles this for delegated
+tasks; only matters for interactive ssh.
 
 ## Invariant 4 — bwrap on Ubuntu 24.04 GitHub runners needs three workarounds
 

--- a/.devcontainer/claude-sandbox/claude-shadow
+++ b/.devcontainer/claude-sandbox/claude-shadow
@@ -92,13 +92,21 @@ bwrap_argv_build() {
     # Single bind-back list. --bind on a missing source would abort
     # bwrap, so each entry is gated on existence. Directories use
     # `-d`, files use `-f`; both flavours map source→dest identically.
+    # The last three (.kube, .config/claude-ssh, bin) are this repo's
+    # deliberate, homelab-scoped reach into the cluster — admin
+    # kubeconfig, a Claude-only ansible SSH key, and the ansible-
+    # installed CLI tools (kubectl, helm, kubeseal, argocd). The user's
+    # personal SSH agent and ~/.ssh stay masked; only a Claude-scoped
+    # key reaches the sandbox. See README-CLAUDE.md / claude-sandbox
+    # skill Invariant 3 for the rationale.
     local rel
-    for rel in .claude .cache .config/gh .config/glab-cli .local/share/uv; do
+    for rel in .claude .cache .config/gh .config/glab-cli .local/share/uv \
+               .kube .config/claude-ssh bin; do
         if [ -d "$home/$rel" ]; then
             argv+=( --bind "$home/$rel" "$home/$rel" )
         fi
     done
-    for rel in .claude.json .local/bin/uv .local/bin/uvx; do
+    for rel in .claude.json .local/bin/uv .local/bin/uvx .ssh/known_hosts; do
         if [ -f "$home/$rel" ]; then
             argv+=( --bind "$home/$rel" "$home/$rel" )
         fi
@@ -157,6 +165,12 @@ bwrap_argv_build() {
     argv+=( --setenv IS_SANDBOX "1" )
     argv+=( --setenv GIT_CONFIG_GLOBAL "$gitconfig_path" )
     argv+=( --setenv GIT_CONFIG_SYSTEM "/dev/null" )
+    # Point ansible at the Claude-scoped key when present. No host SSH
+    # agent is forwarded — sandboxed ansible authenticates with this
+    # key only, so the user's personal keys never reach the sandbox.
+    if [ -f "$home/.config/claude-ssh/id_ed25519" ]; then
+        argv+=( --setenv ANSIBLE_SSH_PRIVATE_KEY_FILE "$home/.config/claude-ssh/id_ed25519" )
+    fi
     local pass_through_var
     for pass_through_var in TERM LANG LC_ALL LC_CTYPE LC_MESSAGES LC_TIME LC_COLLATE LC_NUMERIC LC_MONETARY; do
         if [ -n "${!pass_through_var:-}" ]; then


### PR DESCRIPTION
## Summary

- Bind `~/.kube`, `~/.config/claude-ssh`, and `~/bin` into the sandbox so kubectl + ansible work inside it. Add a file-only bind of `~/.ssh/known_hosts` for ansible's strict-host-key check.
- Set `ANSIBLE_SSH_PRIVATE_KEY_FILE` to the Claude-scoped key path so `ansible-playbook` authenticates with that key only — host SSH agent is still NOT forwarded, keeping the user's GitHub-org-admin keys out.
- Rewrite the `claude-sandbox` skill's Invariant 3 to document this as a deliberate, homelab-scoped reversal with an explicit table of what is/isn't bound. Refused-regressions list still blocks host-agent forwarding, `~/.ssh` directory binds, and `iac2-ssh`-style volumes.
- Update `/verify-sandbox` check 03's strict-under-/root allowlist for the new top-level entries (`.kube`, `.ssh`, `bin`) and the new `.config/claude-ssh` subdir. Add a subcheck asserting `~/.ssh` contains only `known_hosts` so a future directory-bind regression fails noisily.

Stacked on #393 — merge that first.

## Activation

After PR #393 is merged and `just claude-ssh-bootstrap` has been run:

1. Apply this PR.
2. Restart Claude (next sandbox launch re-reads `claude-shadow`).
3. Run `/verify-sandbox` to confirm the 16-check battery passes with the new allowlist.

## Test plan

- [ ] `/verify-sandbox` reports 16/16 PASS with the expanded allowlist.
- [ ] Adversarial probes (phase 2) don't find ESCAPED paths via the new binds.
- [ ] `kubectl get nodes` works from inside the sandbox.
- [ ] `kubectl annotate ... argocd.argoproj.io/refresh=hard` works.
- [ ] `ansible-playbook pb_all.yml --tags tools` runs end-to-end from the sandbox (uses the Claude-scoped key via ANSIBLE_SSH_PRIVATE_KEY_FILE).
- [ ] `SSH_AUTH_SOCK` is unset inside the sandbox (no host agent forwarding).
- [ ] `ls ~/.ssh` shows only `known_hosts` inside the sandbox (no private keys bound).

🤖 Generated with [Claude Code](https://claude.com/claude-code)