### PR TITLE
fix(rkllama): align models mount with upstream /opt/rkllama/models

### DIFF
--- a/kubernetes-services/additions/rkllama/templates/daemonset.yaml
+++ b/kubernetes-services/additions/rkllama/templates/daemonset.yaml
@@ -41,9 +41,6 @@ spec:
             - name: rkllama
               containerPort: 8080
               protocol: TCP
-          env:
-            - name: MODELS_DIR
-              value: /root/RKLLAMA/models
           securityContext:
             privileged: true # required for /dev/rknpu NPU access
           resources:
@@ -53,8 +50,11 @@ spec:
             limits:
               memory: "28Gi" # node04 has 32GB; leave headroom for OS
           volumeMounts:
+            # Matches rkllama_server's hardcoded --models default; the
+            # upstream image flipped from /root/RKLLAMA/models to this
+            # path, which silently hid all installed .rkllm files.
             - name: models
-              mountPath: /root/RKLLAMA/models
+              mountPath: /opt/rkllama/models
             - name: rknpu
               mountPath: /dev/rknpu
           startupProbe:

--- a/roles/tools/files/rkllama-pull
+++ b/roles/tools/files/rkllama-pull
@@ -147,7 +147,7 @@ def do_pull() -> None:
     # contains the filename (its replace() strips all occurrences). Download
     # directly from HuggingFace into the pod's models directory instead.
     model_name = selected_file.replace(".rkllm", "")
-    model_dir = f"/root/RKLLAMA/models/{model_name}"
+    model_dir = f"/opt/rkllama/models/{model_name}"
     dest = f"{model_dir}/{selected_file}"
     url = f"https://huggingface.co/{repo_id}/resolve/main/{selected_file}"
 


### PR DESCRIPTION
## Summary
- Open WebUI showed an empty model list because `rkllama_server` runs with `--models /opt/rkllama/models` (upstream image default flipped from `/root/RKLLAMA/models` at some point), while the DaemonSet still mounted the NFS PVC at the old path. The 6 installed `.rkllm` files were orphaned at a path rkllama no longer scanned.
- Remount the NFS PVC at `/opt/rkllama/models` to match the upstream default, drop the dead `MODELS_DIR` env var (`rkllama_server` only honours the `--models` CLI flag), and update `rkllama-pull` so it downloads into the same path.
- No data move needed — same PVC, just a different mount path inside the container.

## Test plan
- [x] Pushed branch, ran `just switch-branch fix/rkllama-models-path` to point the cluster at it.
- [x] Watched the rkllama DaemonSet roll on node04 with `mountPath: /opt/rkllama/models`.
- [x] `curl http://rkllama.rkllama.svc.cluster.local:8080/api/tags` now returns all 6 installed models (DeepSeek-R1-Distill-Qwen-7B/14B, Llama-3.1-8B, Qwen2.5-3B, Qwen3-1.7B, plus the legacy `model` entry).
- [ ] Confirm models appear in the Open WebUI UI dropdown (poll interval ~30s).
- [ ] After merge: `just switch-branch main` to repoint the cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)