### PR TITLE
docs(rkllama): correct CLI name and document 4-part pull syntax

### DIFF
--- a/docs/how-to/rkllama-models.md
+++ b/docs/how-to/rkllama-models.md
@@ -101,29 +101,42 @@ plain-text progress that the WebUI cannot parse. Use `rkllama-pull` instead.
 
 ## Pull a model directly via kubectl
 
-If you prefer to skip the interactive tool, use `rkllama pull` directly in the pod:
+If you prefer to skip the interactive tool, exec into the pod. The
+binary is actually `rkllama_client` (under `/opt/venv/bin`) — the bare
+`rkllama` name is not on `$PATH`.
+
+Interactive mode prompts for each part:
 
 ```bash
 kubectl exec -n rkllama -it \
   $(kubectl get pod -n rkllama -l app=rkllama -o name | head -1) \
-  -c rkllama -- rkllama pull
+  -c rkllama -- /opt/venv/bin/rkllama_client pull
 ```
-
-Enter the repo ID and filename when prompted:
 
 ```
 Repo ID: ahz-r3v/DeepSeek-R1-Distill-Qwen-7B-rk3588-rkllm-1.1.4
 File:    DeepSeek-R1-Distill-Qwen-7B_W8A8_RK3588_o1.rkllm
+Custom Model Name: deepseek-7b
 ```
 
-Or pass them as a single argument:
+Or pass everything as a **single 4-part argument** — `owner/repo/file.rkllm/custom-name`:
 
 ```bash
-kubectl exec -n rkllama -it \
+kubectl exec -n rkllama \
   $(kubectl get pod -n rkllama -l app=rkllama -o name | head -1) \
-  -c rkllama -- rkllama pull \
-  ahz-r3v/DeepSeek-R1-Distill-Qwen-7B-rk3588-rkllm-1.1.4/DeepSeek-R1-Distill-Qwen-7B_W8A8_RK3588_o1.rkllm
+  -c rkllama -- /opt/venv/bin/rkllama_client pull \
+  ahz-r3v/DeepSeek-R1-Distill-Qwen-7B-rk3588-rkllm-1.1.4/DeepSeek-R1-Distill-Qwen-7B_W8A8_RK3588_o1.rkllm/deepseek-7b
 ```
+
+:::{warning}
+The fourth segment (custom name) is **mandatory** for non-interactive
+use. The client does `rsplit('/', 1)` to peel off the model name, so if
+you only supply three segments the actual filename gets stripped off
+and only `owner/repo` is sent to the server — which fails with
+`Error: Invalid path 'owner/repo'`. The client prints "Download
+complete" at the end regardless of success, so the failure is easy to
+miss. Always verify with `rkllama_client list` afterwards.
+:::
 
 ## List and delete models
 
@@ -132,16 +145,22 @@ kubectl exec -n rkllama -it \
 ```bash
 kubectl exec -n rkllama \
   $(kubectl get pod -n rkllama -l app=rkllama -o name | head -1) \
-  -c rkllama -- rkllama list
+  -c rkllama -- /opt/venv/bin/rkllama_client list
 ```
 
-**Delete a model** (use the short name shown by `list`):
+**Delete a model.** The `rkllama_client rm` command expects the
+original `<file>.rkllm` filename, not the short name from `list`, which
+is awkward when you have to remember the full quantisation suffix.
+Easier: just remove the model directory on the NFS-backed PV:
 
 ```bash
-kubectl exec -n rkllama \
-  $(kubectl get pod -n rkllama -l app=rkllama -o name | head -1) \
-  -c rkllama -- rkllama rm deepseek-r1-distill-qwen-7b
+POD=$(kubectl get pod -n rkllama -l app=rkllama -o name | head -1)
+kubectl exec -n rkllama $POD -c rkllama -- rm -rf /opt/rkllama/models/<short-name>
 ```
+
+The `cuda/` subdirectory under `/opt/rkllama/models/` holds the
+**llamacpp** GGUF models on the same NFS share — do not delete it
+when wiping rkllama models.
 
 ## Memory limits
 


### PR DESCRIPTION
## Summary

- The in-pod binary is `/opt/venv/bin/rkllama_client`; the bare `rkllama` command isn't on `$PATH` inside the image. Replace `rkllama list`/`rkllama rm`/`rkllama pull` with `rkllama_client` in `docs/how-to/rkllama-models.md`.
- Non-interactive `rkllama_client pull` requires a **4-part** path (`owner/repo/file.rkllm/custom-name`). The client does `rsplit('/', 1)` to peel off the model name before posting to the server. With only 3 parts, the actual filename gets stripped off as the "name" and the server returns `Error: Invalid path 'owner/repo'` — but the client still prints "Download complete" and exits 0, so the failure is easy to miss. Added a warning admonition that calls this out and tells you to verify with `rkllama_client list`.
- Replace the `rkllama_client rm` recipe with a direct `rm -rf` of the model directory under `/opt/rkllama/models/`, plus a safety note: the `cuda/` subdirectory under the same NFS root holds the **llamacpp** GGUF models — don't delete it when wiping rkllama models.

Stacked on the existing branch commit (#391-ish — `c87ea43 fix(rkllama): align models mount with upstream /opt/rkllama/models`). Together the two commits document what changed and how to use the renamed paths correctly.

## Test plan

- [x] `python -m sphinx -W docs docs/_build` builds clean (warnings as errors).
- [x] Three real models pulled with the documented 4-part syntax on node04 — `qwen2.5-7b-instruct`, `qwen2.5-coder-7b`, `gemma-2-9b-it` — all listed by `rkllama_client list`.
- [x] Verified the 3-part form fails silently as documented (error in server, "Download complete" in client, exit 0, empty `list`).
- [ ] Reviewer skim of the warning admonition wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)