### PR TITLE
feat(rkllama): overlay image fixes NPU error + auto-evicts model on switch

### DIFF
--- a/.claude/skills/rkllama/SKILL.md
+++ b/.claude/skills/rkllama/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: rkllama
+description: RKLLama (RK3588 NPU LLM server) operations — pod CLI quirks, model layout, hardware pinning, and the silent-failure modes of `rkllama_client pull`.
+---
+
+# RKLLama
+
+RKLLama serves `.rkllm` models on the Rockchip RK3588 NPU. Pinned to
+**node04** (a 32 GB RK1 module) via the DaemonSet's `nodeSelector`. NFS-
+backed PV at `192.168.1.3:/bigdisk/k8s-cluster/models`, mounted in-pod
+at `/opt/rkllama/models`.
+
+## In-pod CLI is `rkllama_client`, not `rkllama`
+
+The image (`ghcr.io/notpunchnox/rkllama:main`) installs the binary at
+`/opt/venv/bin/rkllama_client`. A bare `rkllama` command is not on
+`$PATH`. The `tools` Ansible role installs a host-side `rkllama-pull`
+wrapper that hides this — but that wrapper isn't reachable from the
+Claude sandbox (`--clearenv` strips the path), so direct
+`kubectl exec ... rkllama_client ...` is the sandbox-friendly route.
+
+```bash
+POD=$(kubectl get pod -n rkllama -l app=rkllama -o name | head -1)
+kubectl exec -n rkllama $POD -c rkllama -- /opt/venv/bin/rkllama_client list
+```
+
+## Non-interactive `pull` needs 4 path parts — silent failure otherwise
+
+The client does `model.rsplit('/', 1)` to peel off a "custom model
+name" before posting to the server. So `pull` expects:
+
+```
+owner/repo/file.rkllm/custom-name
+```
+
+If you supply only 3 parts (`owner/repo/file.rkllm`), the **filename**
+gets stripped off as the "name", only `owner/repo` reaches the server,
+and the server returns `Error: Invalid path 'owner/repo'`. **Crucially
+the client still prints `Download complete` and exits 0**, so the loop
+keeps going and you don't notice. Always verify with
+`rkllama_client list` afterwards.
+
+Source: `/opt/rkllama/src/rkllama/client/client.py:309`. Documented in
+`docs/how-to/rkllama-models.md` with a warning admonition.
+
+## Removing models — prefer `rm -rf` of the model dir
+
+`rkllama_client rm` wants the original `<file>.rkllm` filename
+(awkward — you have to remember the full quantisation suffix).
+Direct directory removal is simpler:
+
+```bash
+kubectl exec -n rkllama $POD -c rkllama -- rm -rf /opt/rkllama/models/<short-name>
+```
+
+**Do not delete `/opt/rkllama/models/cuda/`** — that subdirectory is
+the **llamacpp** GGUF models on the same NFS root. Mixing the two
+backends in one NFS share is intentional but means rkllama wipes must
+exclude `cuda/`.
+
+## Hardware envelope (node04)
+
+- Rockchip RK3588: 6 TOPS NPU (3 × 2 TOPS cores), INT8/INT4 only.
+- 32 GB unified RAM (CPU + NPU share). Generic RK1 baseline is 16 GB,
+  but node04 is the upgraded module — confirm in `values.yaml`
+  comments before assuming.
+- Approx W8A8 RAM: 3B ≈ 4 GB, 7B ≈ 9 GB, 8B ≈ 10 GB, 14B ≈ 15 GB
+  (tight). Anything larger than ~14 B will not fit a single RK1.
+
+## Only one big model fits in the NPU at a time
+
+The RK3588 NPU has its own addressable memory ceiling separate from
+the 32 GB system RAM. Two W8A8 7B models cannot coexist — the second
+load fails with:
+
+```
+E RKNN: failed to malloc npu memory, size: 4059037696, flags: 0x2
+E rkllm: rkllm_init failed
+```
+
+But the rkllama HTTP error returned to the client is the unhelpfully
+generic *"Failed to load model X: Unexpected Error … Check the file
+.rkllm is not corrupted, properties in Modelfile … and resources
+available in the server"*. The "corrupted file" wording is misleading
+— check `kubectl logs` for `failed to malloc npu memory` first.
+
+Compounding the trap: `keep_alive` defaults to **30 minutes**. So a
+single chat request via Open-WebUI keeps that model resident for half
+an hour, blocking every other model load until it expires. To switch
+models on demand, explicitly unload first:
+
+```bash
+kubectl exec -n rkllama $POD -c rkllama -- \
+  /opt/venv/bin/rkllama_client unload <currently-loaded-model>
+```
+
+`rkllama_client ps` shows what's currently resident and when it
+expires.
+
+## Recommended quant settings
+
+For a 32 GB node with no other competing workloads:
+`w8a8 opt-1 hybrid-ratio-1.0` — plain w8a8 (not group-quantised),
+optimisation level 1 (faster), maximum NPU offload. The
+`w8a8_g128`/`g256`/`g512` group-quantised variants are slightly better
+quality but larger and not always available for all hybrid ratios.
+
+## Finding `.rkllm` conversions on Hugging Face
+
+The active community converters are **`c01zaut`** (broadest catalog,
+runtime 1.1.4 builds) and **`ahz-r3v`** (DeepSeek family). Search:
+
+```bash
+curl -s "https://huggingface.co/api/models?author=c01zaut&limit=80" \
+  | jq -r '.[] | select(.id | test("rk3588"; "i")) | .id'
+```
+
+Most useful runtime version is **1.1.4** — older `1.1.0`–`1.1.2`
+conversions still work but lack newer model families. **Mistral 7B has
+no rkllm conversion** on HF (as of 2026-05); Llama / Qwen / Gemma / Phi
+families are all covered.

--- a/.github/workflows/rkllama-overlay.yml
+++ b/.github/workflows/rkllama-overlay.yml
@@ -1,0 +1,59 @@
+name: rkllama Overlay Container
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "rkllama-overlay/**"
+  pull_request:
+    paths:
+      - "rkllama-overlay/**"
+
+jobs:
+  container:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create tags for publishing image
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/rkllama-overlay
+          tags: |
+            # On main: "latest" + short SHA
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            # On PR/branch: "beta" + short SHA
+            type=raw,value=beta,enable=${{ github.ref != 'refs/heads/main' }}
+            type=sha,prefix=sha-
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
+        with:
+          context: ./rkllama-overlay
+          platforms: linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/kubernetes-services/additions/rkllama/templates/daemonset.yaml
+++ b/kubernetes-services/additions/rkllama/templates/daemonset.yaml
@@ -35,7 +35,7 @@ spec:
           # OpenAI/Ollama-compatible LLM server backed by Rockchip RKLLM SDK (NPU-accelerated)
           # https://github.com/NotPunchnox/rkllama
           # Runs on port 8080 internally; nginx sidecar fronts on 8082.
-          image: ghcr.io/notpunchnox/rkllama:main
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: Always
           ports:
             - name: rkllama

--- a/kubernetes-services/additions/rkllama/values.yaml
+++ b/kubernetes-services/additions/rkllama/values.yaml
@@ -7,3 +7,9 @@ nfs:
 # Single node the DaemonSet pins to (only one RK1 has enough RAM for
 # the NPU model). Override in kubernetes-services/values.yaml.
 node: node04
+# Container image for the rkllama server. Defaults point at upstream
+# so standalone `helm template` works; cluster deploys override to the
+# `rkllama-overlay` image so the in-tree patches are applied.
+image:
+  repository: ghcr.io/notpunchnox/rkllama
+  tag: main

--- a/kubernetes-services/templates/rkllama.yaml
+++ b/kubernetes-services/templates/rkllama.yaml
@@ -23,6 +23,9 @@ spec:
             server: {{ .Values.rkllama.nfs.server | quote }}
             path: {{ .Values.rkllama.nfs.path | quote }}
           node: {{ .Values.rkllama.node | quote }}
+          image:
+            repository: {{ .Values.rkllama.image.repository | quote }}
+            tag: {{ .Values.rkllama.image.tag | quote }}
     - path: ./kubernetes-services/additions/ingress
       repoURL: {{ .Values.repo_remote }}
       targetRevision: {{ .Values.repo_branch }}

--- a/kubernetes-services/values.yaml
+++ b/kubernetes-services/values.yaml
@@ -15,14 +15,14 @@ rkllama:
   # of your RK1 nodes when forking; default matches this cluster's
   # node04 (32GB RAM).
   node: node04
-  # Container image — defaults to upstream so a fresh clone deploys a
-  # known-working baseline. The in-tree overlay (rkllama-overlay/) is
-  # built and published by .github/workflows/rkllama-overlay.yml; flip
-  # `repository`/`tag` to `ghcr.io/<owner>/rkllama-overlay` + the
-  # published `sha-<short>` to pick up the cluster patches.
+  # Container image — points at the in-tree overlay so the cluster
+  # picks up the patches in rkllama-overlay/patches/ (clearer error
+  # message, automatic NPU eviction). `:beta` is the moving tag for
+  # non-main builds; after merge to main, repin to a `sha-<short>` if
+  # you want immutability across overlay changes.
   image:
-    repository: ghcr.io/notpunchnox/rkllama
-    tag: main
+    repository: ghcr.io/gilesknap/rkllama-overlay
+    tag: beta
 # llama.cpp CUDA server configuration.
 # Uses a separate NFS subdirectory from rkllama — the two backends use
 # incompatible model formats (GGUF for CUDA vs RKLLM for ARM NPU) so

--- a/kubernetes-services/values.yaml
+++ b/kubernetes-services/values.yaml
@@ -15,6 +15,14 @@ rkllama:
   # of your RK1 nodes when forking; default matches this cluster's
   # node04 (32GB RAM).
   node: node04
+  # Container image — defaults to upstream so a fresh clone deploys a
+  # known-working baseline. The in-tree overlay (rkllama-overlay/) is
+  # built and published by .github/workflows/rkllama-overlay.yml; flip
+  # `repository`/`tag` to `ghcr.io/<owner>/rkllama-overlay` + the
+  # published `sha-<short>` to pick up the cluster patches.
+  image:
+    repository: ghcr.io/notpunchnox/rkllama
+    tag: main
 # llama.cpp CUDA server configuration.
 # Uses a separate NFS subdirectory from rkllama — the two backends use
 # incompatible model formats (GGUF for CUDA vs RKLLM for ARM NPU) so

--- a/rkllama-overlay/Dockerfile
+++ b/rkllama-overlay/Dockerfile
@@ -1,0 +1,20 @@
+# Thin overlay over upstream rkllama: applies in-tree patches at build
+# time. Keeps us off a hard fork while we wait for upstream merges.
+#
+# Pin the base to a content digest so rebuilds are reproducible. To bump:
+#   curl -s "https://ghcr.io/token?scope=repository:notpunchnox/rkllama:pull" \
+#     | python -c 'import sys,json; print(json.load(sys.stdin)["token"])' \
+#     | xargs -I{} curl -sI -H 'Authorization: Bearer {}' \
+#       -H 'Accept: application/vnd.oci.image.index.v1+json' \
+#       https://ghcr.io/v2/notpunchnox/rkllama/manifests/main \
+#     | grep -i docker-content-digest
+FROM ghcr.io/notpunchnox/rkllama@sha256:3ab91181b5caf1f4f3e4e55f5c0d7e9ef7f261a13c81752fc85d728fad92effe
+
+COPY patches/ /tmp/patches/
+RUN set -e; \
+    cd /opt/rkllama; \
+    for p in /tmp/patches/*.patch; do \
+      echo "Applying $p"; \
+      patch -p1 --no-backup-if-mismatch < "$p"; \
+    done; \
+    rm -rf /tmp/patches

--- a/rkllama-overlay/README.md
+++ b/rkllama-overlay/README.md
@@ -1,0 +1,47 @@
+# rkllama-overlay
+
+Thin container overlay on top of [`ghcr.io/notpunchnox/rkllama`](https://github.com/NotPunchnox/rkllama).
+Applies in-tree patches at image build time and republishes to
+`ghcr.io/<owner>/rkllama-overlay`. The cluster DaemonSet
+(`kubernetes-services/additions/rkllama`) consumes this image instead
+of upstream.
+
+The overlay exists so we can ship targeted fixes without forking the
+project. Each patch in `patches/` is a unified diff against upstream's
+working tree (run with `patch -p1` from `/opt/rkllama` inside the
+image). Patches are applied in lexical order, so a numeric prefix
+controls sequence.
+
+## Current patches
+
+- **`01-clearer-error.patch`** — Replaces the misleading "file may be
+  corrupted" error returned when an RKLLM load fails. The original
+  wording points at the model file as the likely culprit; the real
+  most-common cause on RK3588 is NPU memory contention (one RKLLM at
+  a time). The new wording names that.
+- **`02-auto-evict-rkllm.patch`** — Before loading a second RKLLM
+  worker, evict any incumbent. Upstream's existing eviction logic
+  only triggers on low system RAM, so it never fires for the NPU
+  case. Result: Open-WebUI model switching now works without manual
+  `rkllama_client unload`.
+
+## Bumping the upstream base
+
+1. Resolve the current `:main` digest (see the comment block at the
+   top of `Dockerfile` for a copy-pasteable one-liner).
+2. Update the `FROM` line in `Dockerfile`.
+3. Re-grep upstream for the patch insertion points and regenerate any
+   patch whose anchors have shifted. `patch --dry-run` is a quick
+   verifier locally; CI builds will fail loudly if a patch no longer
+   applies.
+
+## Publishing
+
+A new image is built and pushed on every change under
+`rkllama-overlay/**` by `.github/workflows/rkllama-overlay.yml`.
+Tags: `latest` (main), `beta` (branches/PRs), and `sha-<short>` for
+both.
+
+The cluster pins to a specific `sha-<short>` via
+`kubernetes-services/values.yaml` so deploys are reproducible — see
+`.claude/skills/rkllama/SKILL.md` for the wider operations context.

--- a/rkllama-overlay/patches/01-clearer-error.patch
+++ b/rkllama-overlay/patches/01-clearer-error.patch
@@ -1,0 +1,11 @@
+--- a/src/rkllama/server/server.py
++++ b/src/rkllama/server/server.py
+@@ -159,7 +159,7 @@
+     model_loaded = variables.worker_manager_rkllm.add_worker(model_name, rkllm_model_path, model_dir, options=request_options, loaded_by=loaded_by)
+ 
+     if not model_loaded:
+-        return None, f"Unexpected Error loading the model {model_name} into memory. Check the file .rkllm is not corrupted, properties in Modelfile (like Context Length allowed by the model) and resources available in the server"
++        return None, f"Failed to load model {model_name}. The RK3588 NPU may already be holding another model (it fits one large model at a time). Check `rkllama_client ps` and unload with `rkllama_client unload <name>`. If no other model is loaded, verify the .rkllm file integrity and Modelfile `NUM_CTX`."
+     else:
+         return None, None
+ 

--- a/rkllama-overlay/patches/02-auto-evict-rkllm.patch
+++ b/rkllama-overlay/patches/02-auto-evict-rkllm.patch
@@ -1,0 +1,19 @@
+--- a/src/rkllama/api/worker.py
++++ b/src/rkllama/api/worker.py
+@@ -722,6 +722,16 @@
+         if model_name not in self.workers.keys():
+ 
+             if is_rkllm_model(model_name):
++                # RK3588 NPU fits one RKLLM model at a time — evict any
++                # incumbent RKLLM worker before allocating a domain id,
++                # otherwise rkllm_init fails with "failed to malloc npu
++                # memory" even though system RAM is free.
++                resident_rkllm = [m for m in self.workers if is_rkllm_model(m)]
++                for rkllm_name in resident_rkllm:
++                    logger.info(f"NPU contention: evicting {rkllm_name} before loading {model_name}")
++                    self.stop_worker(rkllm_name)
++                    time.sleep(1)
++
+                 # Get the available domain id for the RKLLM process
+                 base_domain_id = self.get_available_base_domain_id(reverse_order=True)
+             else:


### PR DESCRIPTION
## Summary

- Add `rkllama-overlay/` — thin overlay image on `ghcr.io/notpunchnox/rkllama@sha256:3ab9118…` with two patches applied at build time, published by a new arm64 GHCR workflow.
- **Commit A** (`6d9b123`): rewrite the misleading *"Unexpected Error … file may be corrupted"* message to name the real cause on RK3588 (NPU already holds another RKLLM).
- **Commit B** (`59c95ac`): auto-evict the resident RKLLM worker before loading a new one, so Open-WebUI model switching works without manual `rkllama_client unload`.

Background: the RK3588 NPU has a driver-level ceiling separate from system RAM, so a second RKLLM load fails with `RKNN: failed to malloc npu memory` even though `psutil.virtual_memory().available` looks fine. Upstream's eviction logic only fires on low system RAM, so it never triggers for this case. Skill notes documenting the underlying behaviour ride along.

The cluster DaemonSet now reads its image from `kubernetes-services/values.yaml` so a tag bump is a values change, not a manifest edit. Commit A wires the plumbing with defaults pointing at upstream; commit B flips to the overlay (`:beta` for now).

## Test plan

- [x] `just check` clean (ansible-lint + sphinx)
- [x] `helm template kubernetes-services` renders the new `image:` block in the rkllama Application valuesObject
- [x] Both patches `patch -p1 --dry-run` cleanly against the upstream `/opt/rkllama` source pulled from the running pod
- [ ] GHCR workflow publishes `:beta` and `sha-<...>` for arm64 on push
- [ ] After ArgoCD sync: cold-error path returns the new wording (e.g. trigger a model load while another is resident *before* commit B's eviction lands — or `grep` the running pod's `server.py:162`)
- [ ] After ArgoCD sync: load model A, then call `/api/chat` for model B via the pod — should evict A automatically and log \`NPU contention: evicting [...]\` instead of returning the old corrupted-file error

## Follow-up (after merge)

- Pin `kubernetes-services/values.yaml` rkllama image tag to a concrete `sha-<short>` instead of `:beta` for reproducibility across overlay changes.
- Upstream both patches to `NotPunchnox/rkllama` once validated in-cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)