### PR TITLE
docs: add user tutorial for connecting to the thoth PKM

### DIFF
--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -38,6 +38,10 @@ land on that node. The existing pinning — `prometheus→node02`,
 not an accident, and new RWO `local-nvme` workloads need to pick
 their own host. This is called out in `CLAUDE.md` as a hard rule.
 
+Already have a cluster (or access to someone else's) and just want to *use*
+the thoth PKM? Skip the install paths and go straight to
+{doc}`tutorials/use-thoth`.
+
 With that mental model in place, pick your install path:
 
 - **{doc}`tutorials/ai-guided-setup`** — let Claude Code run the whole setup
@@ -61,4 +65,5 @@ tutorials/ai-guided-setup
 tutorials/getting-started-tpi
 tutorials/getting-started-generic
 tutorials/common-setup
+tutorials/use-thoth
 ```

--- a/docs/tutorials/use-thoth.md
+++ b/docs/tutorials/use-thoth.md
@@ -1,0 +1,111 @@
+# Use the thoth PKM
+
+:::{important}
+**This tutorial is specific to the author's thoth instance.** It uses the
+real URLs of this cluster's deployment:
+
+- MCP endpoint: `https://thoth.gkcluster.org/mcp`
+- PKM vault repo: `https://github.com/gilesknap/pkm-vault-demo.git`
+
+If you are connecting to **someone else's** thoth installation, replace
+both of these with the URLs they give you. Everything else in the steps
+is identical.
+:::
+
+This is the **user** side of thoth: how to read, edit, and search a thoth
+PKM vault once an administrator has it running. It does not cover deploying
+or operating the server — that is {doc}`/how-to/thoth`. It sticks to the
+minimum needed to actually use the tool day to day.
+
+A thoth PKM has two faces:
+
+- **A Git repo of Markdown notes** (the *vault*). You read and edit it
+  locally in Obsidian; changes sync back over Git.
+- **An MCP server** that lets Claude Code and Claude.ai search and capture
+  into the same vault using `pkm_*` tools.
+
+## Prerequisites
+
+- A GitHub account that the thoth admin has **added to the vault repo** (so
+  you can clone and push) and to thoth's **OAuth allowlist** (so the MCP
+  tools admit you). Without the allowlist, OAuth succeeds but tool calls
+  return 403.
+- [Obsidian](https://obsidian.md/) installed.
+- [Claude Code](https://claude.com/claude-code) and/or a
+  [claude.ai](https://claude.ai/) account, depending on which clients you
+  want.
+
+## 1 -- Clone the vault
+
+Clone the vault repo to a local folder. This folder becomes your Obsidian
+vault.
+
+```bash
+git clone https://github.com/gilesknap/pkm-vault-demo.git ~/pkm-vault
+```
+
+## 2 -- Open the vault in Obsidian
+
+1. Launch Obsidian and choose **Open folder as vault**.
+2. Select the folder you just cloned (`~/pkm-vault`).
+
+You can now read and edit the notes. To keep them in sync with the repo
+(and with whatever thoth and other users capture), add the Git plugin.
+
+### Add the Obsidian Git plugin
+
+1. **Settings → Community plugins → Turn on community plugins**.
+2. **Browse**, search for **Obsidian Git**, **Install**, then **Enable**.
+3. In the plugin's settings, set an auto-sync interval (e.g. **Vault backup
+   interval** = 10 minutes) so edits are committed and pushed, and remote
+   changes are pulled, automatically.
+
+Obsidian Git uses your existing Git credentials for the repo. If pushes are
+rejected, confirm the admin has given your GitHub account write access to
+the vault repo.
+
+## 3 -- Connect Claude Code
+
+Register the MCP server once:
+
+```bash
+claude mcp add --transport http thoth https://thoth.gkcluster.org/mcp
+```
+
+The first session that connects opens a browser for GitHub consent. Approve
+it with the GitHub account that is on the allowlist; the token is cached for
+later sessions. Then, in a session:
+
+```
+/mcp
+```
+
+lists thoth's `pkm_*` tools. To re-authorize later, `claude mcp remove thoth`
+and add it again.
+
+## 4 -- Connect Claude.ai
+
+1. Open [claude.ai](https://claude.ai/) and go to a **Project** (or create
+   one).
+2. Open **Project settings → Connectors** (called **Integrations** in some
+   versions of the UI).
+3. **Add custom integration** and enter the URL
+   `https://thoth.gkcluster.org/mcp`.
+4. Claude.ai redirects you to GitHub to authorize. After consent, thoth's
+   `pkm_*` tools appear in the project.
+
+## Verify
+
+In a fresh Claude Code session or claude.ai Project conversation:
+
+1. Ask Claude to list its tools — the `pkm_*` tools should appear.
+2. Ask it to run a read-only `pkm_*` tool (a search or stats tool) and
+   confirm it returns results rather than an auth error.
+3. Capture a note and confirm it lands as a new Markdown file in the vault
+   (it will appear in Obsidian after the next Git sync).
+
+## See also
+
+- {doc}`/how-to/connect-thoth-mcp` — the MCP OAuth flow in depth, plus
+  troubleshooting for auth loops and vanished tools.
+- {doc}`/how-to/thoth` — deploying and operating a thoth server (admin side).


### PR DESCRIPTION
## Summary

Adds a minimal, user-facing tutorial — `docs/tutorials/use-thoth.md` — for people who just want to *use* the cluster's thoth PKM (as opposed to deploying/operating it).

It covers exactly four steps and nothing more:
1. Clone the vault repo
2. Open it as an Obsidian vault and add the **Obsidian Git** plugin for sync
3. Connect Claude Code to the MCP endpoint
4. Connect claude.ai to the MCP endpoint

Plus a short prerequisites block (GitHub account must be on both the vault repo and thoth's OAuth allowlist) and a quick verify section.

## Notes

- Opens with an **`important` callout** stating the doc is specific to this deployment (`thoth.gkcluster.org`, `pkm-vault-demo`) and that both URLs must be swapped when connecting to someone else's installation.
- Links out to `how-to/connect-thoth-mcp` (OAuth internals + troubleshooting) and `how-to/thoth` (admin side) instead of duplicating them.
- Wired into the `tutorials.md` toctree, with a one-line pointer at the top for users who only want to use thoth rather than build a cluster.

`just check` (ansible-lint) and a clean `sphinx-build` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)