### PR TITLE
feat(headlamp): install the Argo CD plugin

### DIFF
--- a/docs/reference/services.md
+++ b/docs/reference/services.md
@@ -128,7 +128,7 @@ hardware and want the full experience out of the box.
 | cloudflared | Plain manifests | 2026.3.0 | `cloudflared` | — | — | Cloudflare tunnel connector |
 | echo | Plain manifests | 0.9.2 | `echo` | `echo.<domain>` | None | HTTP echo test service |
 | Grafana + Prometheus | `prometheus-community/kube-prometheus-stack` | 83.0.2 | `monitoring` | `grafana.<domain>` | Dex (OIDC) | Monitoring and dashboards |
-| Headlamp | `headlamp/headlamp` | 0.41.0 | `headlamp` | `headlamp.<domain>` | OAuth + Token | Kubernetes dashboard |
+| Headlamp | `headlamp/headlamp` | 0.43.0 | `headlamp` | `headlamp.<domain>` | OAuth + Token | Kubernetes dashboard (with Argo CD plugin) |
 | ingress-nginx | `ingress-nginx/ingress-nginx` | 4.15.1 | `ingress-nginx` | — | — | Ingress controller |
 | kernel-settings | Inline DaemonSet | — | `kube-system` | — | — | Sysctl tuning for performance |
 | oauth2-proxy | `oauth2-proxy/oauth2-proxy` | 10.4.2 | `oauth2-proxy` | `oauth2.<domain>` | GitHub | OAuth proxy for Headlamp and Supabase Studio |
@@ -192,6 +192,25 @@ paste a ServiceAccount token generated with
 The Helm chart creates a ClusterRoleBinding granting `cluster-admin` to
 the default ServiceAccount. Resource limits: 50m/128Mi request,
 200m/256Mi limit.
+
+**Argo CD plugin.** The
+[Argo CD plugin](https://github.com/headlamp-k8s/plugins/tree/main/argocd)
+from the Headlamp project adds an Argo CD sidebar section listing
+Applications with their project, source repo, revision, sync status and
+health, plus buttons to sync or refresh an Application. It drives the
+Kubernetes API rather than the Argo CD REST API, so it needs no Argo CD
+credentials — read and patch rights on `applications.argoproj.io` are
+enough, which the chart's `cluster-admin` ClusterRoleBinding already
+covers. No extra RBAC manifests are required.
+
+The plugin is not on ArtifactHub yet, so the chart's `pluginsManager`
+sidecar (which only accepts ArtifactHub URLs) cannot install it. Instead
+`templates/dashboard.yaml` sets `config.pluginsDir` and adds an
+initContainer that downloads the GitHub release tarball, verifies its
+SHA-256, and unpacks it into an emptyDir shared with the Headlamp
+container. Set `headlamp.argocd_plugin.enabled` to `false` in
+`kubernetes-services/values.yaml` to drop the plugin; bump
+`version` and `sha256` together to upgrade it.
 
 ### ingress-nginx
 

--- a/kubernetes-services/templates/dashboard.yaml
+++ b/kubernetes-services/templates/dashboard.yaml
@@ -25,6 +25,48 @@ spec:
             limits:
               cpu: 200m
               memory: 256Mi
+{{- if .Values.headlamp.argocd_plugin.enabled }}
+          # Argo CD plugin (github.com/headlamp-k8s/plugins/tree/main/argocd).
+          # Headlamp loads every subdirectory of pluginsDir at startup, so an
+          # initContainer unpacks the release tarball into a shared emptyDir
+          # before the main container runs. The chart's `pluginsManager`
+          # sidecar is not usable here: it shells out to `pluginctl`, which
+          # only accepts ArtifactHub URLs, and this plugin is not yet
+          # published there. Version and checksum live in values.yaml.
+          config:
+            pluginsDir: /headlamp/plugins
+          initContainers:
+            - name: install-argocd-plugin
+              image: alpine:3.23
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -eu
+                  version={{ .Values.headlamp.argocd_plugin.version }}
+                  tarball=headlamp-k8s-argocd-$version.tar.gz
+                  wget -q -O "/tmp/$tarball" \
+                    "https://github.com/headlamp-k8s/plugins/releases/download/argocd-$version/$tarball"
+                  echo "{{ .Values.headlamp.argocd_plugin.sha256 }}  /tmp/$tarball" | sha256sum -c -
+                  rm -rf /headlamp/plugins/argocd
+                  tar -xzf "/tmp/$tarball" -C /headlamp/plugins
+                  ls -l /headlamp/plugins/argocd
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 200m
+                  memory: 128Mi
+              volumeMounts:
+                - name: plugins
+                  mountPath: /headlamp/plugins
+          volumes:
+            - name: plugins
+              emptyDir: {}
+          volumeMounts:
+            - name: plugins
+              mountPath: /headlamp/plugins
+{{- end }}
 
     - path: ./kubernetes-services/additions/ingress
       repoURL: {{ .Values.repo_remote }}

--- a/kubernetes-services/values.yaml
+++ b/kubernetes-services/values.yaml
@@ -42,6 +42,30 @@ llamacpp:
     contextSize: 8192 # reduce for large models that leave little VRAM for KV cache
     parallel: 2 # reduce for large models; 33B Q5 leaves ~200MB for KV cache
     memoryLimit: "20Gi"
+# Headlamp — the Kubernetes web UI (kubernetes-sigs).
+# The Argo CD plugin adds an "Argo CD" sidebar section listing
+# Applications with sync/health status, plus sync and refresh actions.
+# It talks to the Kubernetes API (not the Argo CD REST API), so it needs
+# no Argo CD credentials — the chart's ClusterRoleBinding already gives
+# the headlamp ServiceAccount enough rights to read and patch
+# `applications.argoproj.io`.
+#
+# The plugin is not published on ArtifactHub yet, so the chart's
+# `pluginsManager` sidecar (which only accepts ArtifactHub URLs) cannot
+# install it. Instead an initContainer unpacks the GitHub release
+# tarball into the plugins directory before Headlamp starts — see
+# templates/dashboard.yaml.
+#
+# To upgrade: pick a newer `argocd-<version>` tag from
+# https://github.com/headlamp-k8s/plugins/releases and update BOTH
+# `version` and `sha256` (the checksum of
+# headlamp-k8s-argocd-<version>.tar.gz). A mismatched checksum fails the
+# initContainer, so the pod will not start with an unverified plugin.
+headlamp:
+  argocd_plugin:
+    enabled: true
+    version: 0.1.0-alpha
+    sha256: 52eec016c40e1abe2c9a797391de0119c94f10c22005f9638389027604e8c39b
 # OAuth2 authentication gateway.
 # Set to true AFTER completing the OAuth setup guide (docs/how-to/oauth-setup).
 # When false, services are accessible without OAuth authentication.


### PR DESCRIPTION
Adds the official [Headlamp Argo CD plugin](https://github.com/headlamp-k8s/plugins/tree/main/argocd) (`@headlamp-k8s/argocd` v0.1.0-alpha) to the Headlamp deployment, giving Argo CD Applications/Projects views inside the dashboard.

## Mechanism

The plugin is **not published on ArtifactHub**, so the chart's `pluginsManager` sidecar can't install it (`pluginctl` rejects any source outside `artifacthub.io/packages/headlamp/`). Instead the Application uses the chart's first-class `initContainers` value to fetch the release tarball, verify its SHA-256, and untar it into a shared `emptyDir` mounted at `config.pluginsDir`. A tampered or truncated download fails the pod rather than silently serving nothing.

No new RBAC: the plugin drives the Kubernetes API, and the `headlamp` ServiceAccount is already bound to `cluster-admin` (verified with `kubectl auth can-i list/patch applications.argoproj.io`).

## Changes

- `kubernetes-services/templates/dashboard.yaml` — plugin wiring, gated on `headlamp.argocd_plugin.enabled`
- `kubernetes-services/values.yaml` — new `headlamp.argocd_plugin` block (`enabled` / `version` / `sha256`)
- `docs/reference/services.md` — Argo CD plugin subsection; also corrects the stale Headlamp chart version in the services table (0.41.0 -> 0.43.0)

## Verification

- `just check` passes clean (ansible-lint 0 warnings, sphinx build succeeded)
- Parent chart renders; the generated `valuesObject` passes headlamp 0.43.0's `values.schema.json`
- Deployed on this branch: app Synced/Healthy, pod 1/1, init container reports checksum `OK`, backend serves `GET /plugins/argocd/main.js`

## Notes

Being off-ArtifactHub, the pinned `version` + `sha256` are not tracked by Renovate — upgrades are manual and both keys must move together.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Argo CD integration to Headlamp, allowing users to view applications and perform synchronization and refresh operations.
  * Headlamp now includes the Argo CD plugin by default.
  * Added configuration options to disable the plugin or select a different plugin version.

* **Bug Fixes**
  * Added release verification to ensure the installed plugin matches its expected checksum.

* **Documentation**
  * Documented the Headlamp upgrade and Argo CD plugin capabilities and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->