### PR TITLE
fix(open-brain-mcp): sort imports to satisfy ruff

### DIFF
--- a/open-brain-mcp/oauth.py
+++ b/open-brain-mcp/oauth.py
@@ -6,8 +6,8 @@ to authenticated users whose GitHub username is on the allowlist.
 
 from __future__ import annotations
 
-import hashlib
 import base64
+import hashlib
 import os
 import secrets
 import time

--- a/open-brain-mcp/server.py
+++ b/open-brain-mcp/server.py
@@ -5,15 +5,14 @@ from __future__ import annotations
 import os
 from contextlib import asynccontextmanager
 
+import db
 import jwt
+from oauth import oauth_routes
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.routing import Mount, Route
 from starlette.types import ASGIApp, Receive, Scope, Send
-
-import db
-from oauth import oauth_routes
 from tools import create_mcp
 
 MCP_JWT_SECRET = os.environ.get("MCP_JWT_SECRET", "")

--- a/open-brain-mcp/tools.py
+++ b/open-brain-mcp/tools.py
@@ -4,13 +4,11 @@ from __future__ import annotations
 
 import base64
 import json
+import os
 from typing import Any
 
-import os
-
-from mcp.server.fastmcp import FastMCP
-
 import db
+from mcp.server.fastmcp import FastMCP
 
 SERVER_URL = os.environ.get("SERVER_URL", "http://localhost:8000")
 SUPABASE_URL = os.environ.get("SUPABASE_URL", "")


### PR DESCRIPTION
The `ruff` CI job started failing on `main` (see the run for #484), reporting `I001 Import block is un-sorted or un-formatted` in `open-brain-mcp/{oauth,server,tools}.py`.

## Cause

Not a code change — a toolchain drift. `.github/workflows/docs.yml` uses `astral-sh/ruff-action@v3` with no `version:` input, so it resolves to the latest ruff release (currently 0.16.3). ruff 0.16 promoted the isort rules (`I`) into the default rule set, and this project has no `[tool.ruff]` config to override it. Existing, previously-passing code became non-compliant without anyone touching it.

## Fix

`ruff check --fix open-brain-mcp` — import reordering only, no behaviour change. Verified against the same version CI uses:

- `uvx ruff@0.16.3 check open-brain-mcp` -> All checks passed
- `uvx ruff@0.16.3 format --check open-brain-mcp` -> 4 files already formatted
- All four modules still parse (`ast.parse`)
- `just check` passes (ansible-lint 0 failures / 0 warnings, sphinx build succeeded)

## Notes

- Because these modules have no `src` / `known-first-party` config, ruff treats the local `db`, `oauth` and `tools` imports as third-party and merges them into that block. Functionally identical. Adding `[tool.ruff] src = ["open-brain-mcp"]` would keep them in their own section, but that is a separate opinion and this code is a candidate for removal, so I have kept the change minimal.
- The underlying drift remains: the next ruff release that changes defaults will break CI again on an unrelated PR. Pinning `version:` in the action (with Renovate tracking it) would make that an explicit bump instead of a surprise. Happy to do that separately if you want it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>