### PR TITLE
Add dynamic NFS provisioning

### DIFF
--- a/argo-cd/argo-project.yaml
+++ b/argo-cd/argo-project.yaml
@@ -19,6 +19,7 @@ spec:
     - "https://kubernetes-sigs.github.io/headlamp/"
     - "https://helm.openwebui.com/"
     - "https://nvidia.github.io/k8s-device-plugin"
+    - "https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/charts"
     - "https://bitnami-labs.github.io/sealed-secrets"
     - "https://oauth2-proxy.github.io/manifests"
     - "https://supabase-community.github.io/supabase-kubernetes"

--- a/kubernetes-services/additions/local-storage/templates/storageclass-local-path.yaml
+++ b/kubernetes-services/additions/local-storage/templates/storageclass-local-path.yaml
@@ -1,0 +1,11 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-path
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "false"
+    # This class is installed by K3s; Argo only owns its desired default state.
+    argocd.argoproj.io/sync-options: Prune=false
+provisioner: rancher.io/local-path
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete

--- a/kubernetes-services/templates/nfs-csi.yaml
+++ b/kubernetes-services/templates/nfs-csi.yaml
@@ -1,0 +1,38 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: nfs-csi
+  namespace: argo-cd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: kubernetes
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: nfs-csi
+  source:
+    chart: csi-driver-nfs
+    repoURL: https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/charts
+    targetRevision: {{ .Values.nfs_csi.chart_version | quote }}
+    helm:
+      valuesObject:
+        storageClass:
+          create: true
+          name: {{ .Values.nfs_csi.storage_class | quote }}
+          annotations:
+            storageclass.kubernetes.io/is-default-class: "true"
+          parameters:
+            server: {{ .Values.nfs_csi.server | quote }}
+            share: {{ .Values.nfs_csi.share | quote }}
+            subDir: ${pvc.metadata.namespace}/${pvc.metadata.name}-${pv.metadata.name}
+            onDelete: retain
+          reclaimPolicy: Retain
+          volumeBindingMode: Immediate
+          mountOptions:
+            - nfsvers=4.1
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/kubernetes-services/values.yaml
+++ b/kubernetes-services/values.yaml
@@ -97,7 +97,7 @@ admin_emails:
 # remain admin-only and ignore this default.
 # Supabase self-hosted stack for Open Brain AI memory.
 # Provides database, auth, PostgREST, Edge Functions, Studio, and Kong gateway.
-enable_supabase: true
+enable_supabase: false
 supabase:
   nfs:
     server: 192.168.1.3
@@ -123,7 +123,7 @@ open_brain_mcp:
 # Deployed from the published OCI Helm chart in the thoth repo. The Secret
 # (thoth-env) is shipped here as a SealedSecret carrier chart; the upstream
 # chart provides Deployment/Service/Ingress.
-enable_thoth: true
+enable_thoth: false
 thoth:
   # OCI chart version published by gilesknap/thoth CI.
   chart_version: "0.8.0-beta.3"
@@ -136,6 +136,13 @@ thoth:
 nfs:
   server: 192.168.1.3
   cluster_share_path: /bigdisk/k8s-cluster
+# Dynamically provisioned RWX volumes. The NFS CSI driver creates one
+# subdirectory per PVC beneath this dedicated NAS share.
+nfs_csi:
+  chart_version: "4.13.4"
+  storage_class: nfs-rwx
+  server: 192.168.1.3
+  share: /k8s-dynamic
 # Local-storage PV map — node-pinned hostPath PVs that survive cluster
 # rebuild (data lives outside /var/lib/rancher). Each entry becomes one
 # PV, pre-bound via claimRef to the chart-generated PVC of the workload


### PR DESCRIPTION
## Summary

- deploy the Kubernetes NFS CSI driver through the app-of-apps
- create default `nfs-rwx` storage backed by `192.168.1.3:/k8s-dynamic`
- retain provisioned PVs and NAS directories on claim deletion
- keep K3s `local-path` available but make it non-default
- disable and prune Supabase and Thoth

## Data impact

Removing the Supabase and Thoth Applications deletes five dynamically provisioned `local-path` PVs with `Delete` reclaim policy. Four static Supabase PVs use `Retain` and remain available.

## Validation

- parent Helm template rendered
- upstream CSI chart 4.13.4 rendered
- server-side dry-run accepted adoption of the existing `local-path` StorageClass
- `just pre-commit` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NFS-backed dynamic storage for read-write-many volumes.
  * Added a local-path storage class configuration for local persistent volumes.
  * Enabled automated deployment and management of the NFS CSI storage integration.

* **Configuration Changes**
  * Disabled the Supabase self-hosted stack.
  * Disabled the Thoth Slack PKM service.
  * Authorized the NFS CSI Helm chart repository for deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->