### PR TITLE
Pin T11 workloads to AMD64 nodes

### DIFF
--- a/argo-cd/argo-project.yaml
+++ b/argo-cd/argo-project.yaml
@@ -17,6 +17,7 @@ spec:
     - "https://charts.jetstack.io"
     - "https://kubernetes.github.io/ingress-nginx"
     - "https://kubernetes-sigs.github.io/headlamp/"
+    - "https://kyverno.github.io/kyverno/"
     - "https://helm.openwebui.com/"
     - "https://nvidia.github.io/k8s-device-plugin"
     - "https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/charts"

--- a/kubernetes-services/additions/t11-mutator/Chart.yaml
+++ b/kubernetes-services/additions/t11-mutator/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: t11-mutator
+description: Personal-cluster scheduling overrides for the T11 test beamline.
+type: application
+version: 0.1.0

--- a/kubernetes-services/additions/t11-mutator/templates/scheduling-policy.yaml
+++ b/kubernetes-services/additions/t11-mutator/templates/scheduling-policy.yaml
@@ -1,0 +1,82 @@
+apiVersion: policies.kyverno.io/v1
+kind: NamespacedMutatingPolicy
+metadata:
+  name: force-amd64-scheduling
+  namespace: {{ .Values.namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  failurePolicy: Fail
+  reinvocationPolicy: IfNeeded
+  evaluation:
+    admission:
+      enabled: true
+    mutateExisting:
+      enabled: false
+  matchConstraints:
+    resourceRules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+  matchConditions:
+    - name: all-t11-pods
+      expression: "true"
+  mutations:
+    - patchType: JSONPatch
+      jsonPatch:
+        expression: |
+          has(object.spec.nodeSelector) ?
+          [
+            JSONPatch{
+              op: "add",
+              path: "/spec/nodeSelector/kubernetes.io~1arch",
+              value: "amd64"
+            }
+          ] :
+          [
+            JSONPatch{
+              op: "add",
+              path: "/spec/nodeSelector",
+              value: {"kubernetes.io/arch": "amd64"}
+            }
+          ]
+    - patchType: JSONPatch
+      jsonPatch:
+        expression: |
+          object.spec.?tolerations.orValue([]).exists(t,
+            t.key == "workstation" &&
+            t.operator == "Equal" &&
+            t.value == "true" &&
+            t.effect == "NoSchedule"
+          ) ?
+          [] :
+          has(object.spec.tolerations) ?
+          [
+            JSONPatch{
+              op: "add",
+              path: "/spec/tolerations/-",
+              value: {
+                "key": "workstation",
+                "operator": "Equal",
+                "value": "true",
+                "effect": "NoSchedule"
+              }
+            }
+          ] :
+          [
+            JSONPatch{
+              op: "add",
+              path: "/spec/tolerations",
+              value: [{
+                "key": "workstation",
+                "operator": "Equal",
+                "value": "true",
+                "effect": "NoSchedule"
+              }]
+            }
+          ]

--- a/kubernetes-services/additions/t11-mutator/values.yaml
+++ b/kubernetes-services/additions/t11-mutator/values.yaml
@@ -1,0 +1,1 @@
+namespace: t11-beamline

--- a/kubernetes-services/templates/kyverno.yaml
+++ b/kubernetes-services/templates/kyverno.yaml
@@ -1,0 +1,45 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kyverno
+  namespace: argo-cd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: kubernetes
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kyverno
+  sources:
+    - chart: kyverno
+      repoURL: https://kyverno.github.io/kyverno/
+      targetRevision: {{ .Values.kyverno.chart_version | quote }}
+      helm:
+        valuesObject:
+          admissionController:
+            replicas: 1
+          backgroundController:
+            enabled: false
+          cleanupController:
+            enabled: false
+          reportsController:
+            enabled: false
+    - path: ./kubernetes-services/additions/t11-mutator
+      repoURL: {{ .Values.repo_remote }}
+      targetRevision: {{ .Values.repo_branch }}
+      helm:
+        valuesObject:
+          namespace: {{ .Values.kyverno.t11_namespace | quote }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m

--- a/kubernetes-services/values.yaml
+++ b/kubernetes-services/values.yaml
@@ -143,6 +143,10 @@ nfs_csi:
   storage_class: nfs-rwx
   server: 192.168.1.3
   share: /k8s-dynamic
+# Personal-cluster policy engine and T11 scheduling override.
+kyverno:
+  chart_version: "3.9.1"
+  t11_namespace: t11-beamline
 # Local-storage PV map — node-pinned hostPath PVs that survive cluster
 # rebuild (data lives outside /var/lib/rancher). Each entry becomes one
 # PV, pre-bound via claimRef to the chart-generated PVC of the workload


### PR DESCRIPTION
## Summary
- deploy a minimal Kyverno admission controller
- add a policy scoped to the `t11-beamline` namespace
- force all newly created T11 Pods onto AMD64 nodes
- tolerate the workstation taint while preserving existing scheduling settings

## Validation
- `just pre-commit`
- Helm-rendered the parent and policy charts
- Kyverno CLI 1.19.1 applied the policy successfully to Pods with empty and pre-existing scheduling settings
