### PR TITLE
Add T11 gateway service account

### DIFF
--- a/kubernetes-services/additions/t11-mutator/templates/gateway-service-account.yaml
+++ b/kubernetes-services/additions/t11-mutator/templates/gateway-service-account.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default-full-access-mounted
+  namespace: {{ .Values.namespace }}
+automountServiceAccountToken: true
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gateway-discovery
+  namespace: {{ .Values.namespace }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gateway-discovery
+  namespace: {{ .Values.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: gateway-discovery
+subjects:
+  - kind: ServiceAccount
+    name: default-full-access-mounted
+    namespace: {{ .Values.namespace }}


### PR DESCRIPTION
## Summary
- create the `default-full-access-mounted` ServiceAccount expected by the EPICS gateway chart
- mount its Kubernetes API token
- grant namespace-scoped read access to Pods and Services, matching the gateway discovery code

## Validation
- Helm render
- Kubernetes server-side dry run
- `just pre-commit`
