### PR TITLE
Narrow T11 AMD64 scheduling policy

### DIFF
--- a/kubernetes-services/additions/t11-mutator/templates/scheduling-policy.yaml
+++ b/kubernetes-services/additions/t11-mutator/templates/scheduling-policy.yaml
@@ -24,8 +24,30 @@ spec:
         resources:
           - pods
   matchConditions:
-    - name: all-t11-pods
-      expression: "true"
+    - name: uses-amd64-only-image
+      expression: >-
+        [
+          "ghcr.io/diamondlightsource/blueapi",
+          "ghcr.io/diamondlightsource/numtracker",
+          "ghcr.io/epics-containers/epics-gateways-runtime"
+        ].exists(repo,
+          object.spec.containers.exists(container,
+            container.image == repo ||
+            container.image.startsWith(repo + ":") ||
+            container.image.startsWith(repo + "@")
+          ) ||
+          object.spec.?initContainers.orValue([]).exists(container,
+            container.image == repo ||
+            container.image.startsWith(repo + ":") ||
+            container.image.startsWith(repo + "@")
+          )
+        ) ||
+        object.spec.containers.exists(container,
+          container.image.startsWith("ghcr.io/epics-containers/ioc-")
+        ) ||
+        object.spec.?initContainers.orValue([]).exists(container,
+          container.image.startsWith("ghcr.io/epics-containers/ioc-")
+        )
   mutations:
     - patchType: JSONPatch
       jsonPatch:
@@ -43,40 +65,5 @@ spec:
               op: "add",
               path: "/spec/nodeSelector",
               value: {"kubernetes.io/arch": "amd64"}
-            }
-          ]
-    - patchType: JSONPatch
-      jsonPatch:
-        expression: |
-          object.spec.?tolerations.orValue([]).exists(t,
-            t.key == "workstation" &&
-            t.operator == "Equal" &&
-            t.value == "true" &&
-            t.effect == "NoSchedule"
-          ) ?
-          [] :
-          has(object.spec.tolerations) ?
-          [
-            JSONPatch{
-              op: "add",
-              path: "/spec/tolerations/-",
-              value: {
-                "key": "workstation",
-                "operator": "Equal",
-                "value": "true",
-                "effect": "NoSchedule"
-              }
-            }
-          ] :
-          [
-            JSONPatch{
-              op: "add",
-              path: "/spec/tolerations",
-              value: [{
-                "key": "workstation",
-                "operator": "Equal",
-                "value": "true",
-                "effect": "NoSchedule"
-              }]
             }
           ]


### PR DESCRIPTION
## Summary
- pin Pods only when a regular or init container uses a known AMD64-only image
- cover every `ghcr.io/epics-containers/ioc-*` repository, independent of tag or digest
- keep BlueAPI, Numtracker, and EPICS Gateways explicitly pinned
- stop adding the workstation toleration

## Validation
- Kyverno CLI 1.19.1: future IOC repository and init-container digest are pinned
- Kyverno CLI 1.19.1: multi-arch and prefix-lookalike images are skipped
- `just pre-commit`
