### PR TITLE
Delete NFS volumes with their claims

### DIFF
--- a/docs/how-to/alternative-storage.md
+++ b/docs/how-to/alternative-storage.md
@@ -152,7 +152,7 @@ spec:
           storageClass:
             create: true
             name: nfs-csi
-            reclaimPolicy: Retain
+            reclaimPolicy: Delete
             server: 192.168.1.100       # Your NFS server IP
             share: /export/k8s          # Your NFS export path
 ```

--- a/kubernetes-services/templates/nfs-csi.yaml
+++ b/kubernetes-services/templates/nfs-csi.yaml
@@ -25,8 +25,8 @@ spec:
             server: {{ .Values.nfs_csi.server | quote }}
             share: {{ .Values.nfs_csi.share | quote }}
             subDir: ${pvc.metadata.namespace}/${pvc.metadata.name}-${pv.metadata.name}
-            onDelete: retain
-          reclaimPolicy: Retain
+            onDelete: delete
+          reclaimPolicy: Delete
           volumeBindingMode: Immediate
           mountOptions:
             - nfsvers=4.1

--- a/kubernetes-services/values.yaml
+++ b/kubernetes-services/values.yaml
@@ -137,7 +137,9 @@ nfs:
   server: 192.168.1.3
   cluster_share_path: /bigdisk/k8s-cluster
 # Dynamically provisioned RWX volumes. The NFS CSI driver creates one
-# subdirectory per PVC beneath this dedicated NAS share.
+# subdirectory per PVC beneath this dedicated NAS share and removes it when the
+# PVC is deliberately deleted. Workload charts retain durable PVCs across
+# Helm/Argo removal.
 nfs_csi:
   chart_version: "4.13.4"
   storage_class: nfs-rwx


### PR DESCRIPTION
## Summary

- make dynamically provisioned `nfs-rwx` PVs use `reclaimPolicy: Delete`
- make the NFS CSI driver delete the provisioned subdirectory when its PVC is deliberately deleted
- document that workload charts retain durable PVCs across Helm/Argo removal

## Validation

- `just pre-commit`
- Helm template rendering
- Kubernetes server-side dry-run of a StorageClass with the new policy

## Deployment note

The existing StorageClass fields are immutable. After merge, `nfs-rwx` needs a one-time delete/recreate after the desired Argo configuration has updated. Existing bound PVCs/PVs are not being deleted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that dynamically provisioned NFS storage is deleted when its PVC is deliberately removed.
  - Documented that workload-managed persistent volumes remain durable when their Helm or Argo resources are removed.

- **Configuration**
  - Updated the NFS storage policy so deleting a PVC also deletes its underlying volume and data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->